### PR TITLE
Fix NPE resulting from HoverViewState's callback after it already lost control

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
@@ -31,11 +31,16 @@ class HoverViewStateClosed extends BaseHoverViewState {
     private static final String TAG = "HoverMenuViewStateClosed";
 
     private HoverView mHoverView;
+    private boolean mHasControl = false;
 
     @Override
     public void takeControl(@NonNull HoverView hoverView) {
         Log.d(TAG, "Taking control.");
         super.takeControl(hoverView);
+        if (mHasControl) {
+            throw new RuntimeException("Cannot take control of a FloatingTab when we already control one.");
+        }
+        mHasControl = true;
         mHoverView = hoverView;
         mHoverView.notifyListenersClosing();
         mHoverView.mState = this;
@@ -47,6 +52,9 @@ class HoverViewStateClosed extends BaseHoverViewState {
             selectedTab.disappear(new Runnable() {
                 @Override
                 public void run() {
+                    if (!mHasControl) {
+                        return;
+                    }
                     mHoverView.mScreen.destroyChainedTab(selectedTab);
                     mHoverView.notifyListenersClosed();
                 }
@@ -59,6 +67,11 @@ class HoverViewStateClosed extends BaseHoverViewState {
     }
 
     private void changeState(@NonNull HoverViewState nextState) {
+        Log.d(TAG, "Giving up control.");
+        if (!mHasControl) {
+            throw new RuntimeException("Cannot give control to another HoverMenuController when we don't have the HoverTab.");
+        }
+        mHasControl = false;
         mHoverView.setState(nextState);
         mHoverView = null;
     }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
@@ -67,7 +67,6 @@ class HoverViewStateClosed extends BaseHoverViewState {
     }
 
     private void changeState(@NonNull HoverViewState nextState) {
-        Log.d(TAG, "Giving up control.");
         if (!mHasControl) {
             throw new RuntimeException("Cannot give control to another HoverMenuController when we don't have the HoverTab.");
         }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
@@ -28,7 +28,7 @@ import static android.view.View.GONE;
  */
 class HoverViewStateClosed extends BaseHoverViewState {
 
-    private static final String TAG = "HoverMenuViewStateClosed";
+    private static final String TAG = "HoverViewStateClosed";
 
     private HoverView mHoverView;
     private boolean mHasControl = false;

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -37,7 +37,7 @@ import static android.view.View.VISIBLE;
  */
 class HoverViewStateCollapsed extends BaseHoverViewState {
 
-    private static final String TAG = "HoverMenuViewStateCollapsed";
+    private static final String TAG = "HoverViewStateCollapsed";
 
     private HoverView mHoverView;
     private FloatingTab mFloatingTab;

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -108,6 +108,9 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mHoverView.post(new Runnable() {
             @Override
             public void run() {
+                if (!mHasControl) {
+                    return;
+                }
                 if (wasFloatingTabVisible) {
                     sendToDock();
                 } else {
@@ -303,6 +306,9 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mFloatingTab.dock(new Runnable() {
             @Override
             public void run() {
+                if (!mHasControl) {
+                    return;
+                }
                 onDocked();
             }
         });

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
@@ -57,6 +57,9 @@ class HoverViewStateExpanded extends BaseHoverViewState {
     private final Runnable mShowTabsRunnable = new Runnable() {
         @Override
         public void run() {
+            if (!mHasControl) {
+                return;
+            }
             mHoverView.mScreen.getShadeView().show();
             mHoverView.mScreen.getContentDisplay().selectedTabIs(mSelectedTab);
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
@@ -38,7 +38,7 @@ import java.util.Map;
  */
 class HoverViewStateExpanded extends BaseHoverViewState {
 
-    private static final String TAG = "HoverMenuViewStateExpanded";
+    private static final String TAG = "HoverViewStateExpanded";
     private static final int ANCHOR_TAB_X_OFFSET_IN_PX = 100;
     private static final int ANCHOR_TAB_Y_OFFSET_IN_PX = 100;
     private static final int TAB_SPACING_IN_PX = 200;


### PR DESCRIPTION
https://github.com/Buzzvil/hover/pull/1 이 PR에서 NPE fix 만 분리했습니다.

- If each of the HoverViewState's callback is fired after it has lost control (by `changeState()`), the NPE can occur because mHoverView has been set to null.
- Added checking whether the HoverViewState instance still has control (by checking `mHasControl`) in each of the callbacks.

기존 마스터 상태에서 샘플을 빌드해서 쓸때, State( = HoverViewStateClosed, HoverViewStateCollapsed, HoverViewStateExpanded 중 하나) 들을 빠르게 변경하면 (ex. Expanded 상태로 변하는 중에 백버튼 눌러서 Collapsed 로 만들기) 바로 NPE 가 발생하는 등 불안정한 상태였습니다.
원인을 분석해 보니 State 가 다른 State 로 전환될 때 이전 State 에서의 HoverView 에 대한 레퍼런스를 null 처리로 끊어버리는데, 몇가지 콜백들이 다른 State 로 전환된 이후에 발생할 수 있어서 모든 콜백에 대해 현재 컨트롤을 가지고 있는지 (기존에 정의되어 있던 변수, mHasControl) 를 확인하는 식으로 NPE 를 방지했습니다.