### PR TITLE
[BZZRWRDD-165] MessageView 영역도 drag, tab 가능하게 만들기

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/Dragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Dragger.java
@@ -15,8 +15,8 @@
  */
 package io.mattcarroll.hover;
 
+import android.graphics.Rect;
 import android.support.annotation.NonNull;
-import android.view.View;
 
 /**
  * Reports user drag behavior on the screen to a {@link DragListener}.
@@ -26,9 +26,9 @@ public interface Dragger {
     /**
      * Starts reporting user drag behavior given a drag area represented by {@code controlBounds}.
      * @param dragListener listener that receives information about drag behavior
-     * @param draggedView the View to be start dragging
+     * @param rect Rect area to be draggable
      */
-    void activate(@NonNull DragListener dragListener, @NonNull View draggedView);
+    void activate(@NonNull DragListener dragListener, @NonNull Rect rect);
 
     /**
      * Stops monitoring and reporting user drag behavior.

--- a/hover/src/main/java/io/mattcarroll/hover/Dragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Dragger.java
@@ -15,8 +15,8 @@
  */
 package io.mattcarroll.hover;
 
-import android.graphics.Point;
 import android.support.annotation.NonNull;
+import android.view.View;
 
 /**
  * Reports user drag behavior on the screen to a {@link DragListener}.
@@ -26,9 +26,9 @@ public interface Dragger {
     /**
      * Starts reporting user drag behavior given a drag area represented by {@code controlBounds}.
      * @param dragListener listener that receives information about drag behavior
-     * @param dragStartCenterPosition initial touch point to start dragging
+     * @param draggedView the View to be start dragging
      */
-    void activate(@NonNull DragListener dragListener, @NonNull Point dragStartCenterPosition);
+    void activate(@NonNull DragListener dragListener, @NonNull View draggedView);
 
     /**
      * Stops monitoring and reporting user drag behavior.

--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -70,12 +70,10 @@ public class HoverView extends RelativeLayout {
     @NonNull
     private static Dragger createWindowDragger(@NonNull Context context,
                                                @NonNull WindowViewController windowViewController) {
-        int touchDiameter = context.getResources().getDimensionPixelSize(R.dimen.hover_exit_radius);
         int slop = ViewConfiguration.get(context).getScaledTouchSlop();
         return new InWindowDragger(
                 context,
                 windowViewController,
-                touchDiameter,
                 slop
         );
     }
@@ -120,11 +118,9 @@ public class HoverView extends RelativeLayout {
 
     @NonNull
     private Dragger createInViewDragger(@NonNull Context context) {
-        int touchDiameter = context.getResources().getDimensionPixelSize(R.dimen.hover_exit_radius);
         int slop = ViewConfiguration.get(context).getScaledTouchSlop();
         return new InViewDragger(
                 this,
-                touchDiameter,
                 slop
         );
     }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -16,6 +16,7 @@
 package io.mattcarroll.hover;
 
 import android.graphics.Point;
+import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.util.ListUpdateCallback;
@@ -42,13 +43,13 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     private static final float MAX_TAB_VERTICAL_POSITION = 1.0f;
 
     protected HoverView mHoverView;
-    private FloatingTab mFloatingTab;
+    protected FloatingTab mFloatingTab;
     private HoverMenu.Section mSelectedSection;
     private int mSelectedSectionIndex = -1;
     private boolean mHasControl = false;
     private boolean mIsCollapsed = false;
     private boolean mIsDocked = false;
-    private Dragger.DragListener mDragListener;
+    protected Dragger.DragListener mDragListener;
     private Listener mListener;
 
     private final View.OnLayoutChangeListener mOnLayoutChangeListener = new View.OnLayoutChangeListener() {
@@ -359,7 +360,9 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     }
 
     protected void activateDragger() {
-        mHoverView.mDragger.activate(mDragListener, mFloatingTab);
+        final Rect visibleRect = new Rect();
+        mFloatingTab.getGlobalVisibleRect(visibleRect);
+        mHoverView.mDragger.activate(mDragListener, visibleRect);
     }
 
     protected void deactivateDragger() {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -355,7 +355,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
     }
 
-    private void moveTabTo(@NonNull Point position) {
+    protected void moveTabTo(@NonNull Point position) {
         mFloatingTab.moveTo(position);
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -358,11 +358,11 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mFloatingTab.moveTo(position);
     }
 
-    private void activateDragger() {
-        mHoverView.mDragger.activate(mDragListener, mFloatingTab.getPosition());
+    protected void activateDragger() {
+        mHoverView.mDragger.activate(mDragListener, mFloatingTab);
     }
 
-    private void deactivateDragger() {
+    protected void deactivateDragger() {
         mHoverView.mDragger.deactivate();
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -15,6 +15,7 @@
  */
 package io.mattcarroll.hover;
 
+import android.graphics.Point;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.util.Log;
@@ -61,6 +62,16 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     public void collapse() {
         changeState(mHoverView.mCollapsed);
+    }
+
+    @Override
+    protected void moveTabTo(@NonNull Point position) {
+        final int floatingTabOffset = mMessageView.getWidth() / 2;
+        if (mHoverView.mCollapsedDock.sidePosition().getSide() == SideDock.SidePosition.RIGHT) {
+            mFloatingTab.moveTo(new Point(position.x + floatingTabOffset, position.y));
+        } else {
+            mFloatingTab.moveTo(new Point(position.x - floatingTabOffset, position.y));
+        }
     }
 
     @Override

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -15,6 +15,7 @@
  */
 package io.mattcarroll.hover;
 
+import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
@@ -26,13 +27,15 @@ import android.util.Log;
 class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
     private static final String TAG = "HoverViewStatePreviewed";
+    private TabMessageView mMessageView;
 
     @Override
     public void takeControl(@NonNull HoverView hoverView) {
         super.takeControl(hoverView);
         mHoverView.mState = this;
         mHoverView.notifyListenersPreviewing();
-        mHoverView.mScreen.showTabContentView(mHoverView.mSelectedSectionId, mHoverView.mCollapsedDock, new Runnable() {
+        mMessageView = mHoverView.mScreen.getTabMessageView(mHoverView.mSelectedSectionId);
+        mMessageView.appear(mHoverView.mCollapsedDock, new Runnable() {
             @Override
             public void run() {
                 mHoverView.notifyListenersPreviewed();
@@ -43,9 +46,9 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     protected void changeState(@NonNull final HoverViewState nextState) {
         if (nextState instanceof HoverViewStateCollapsed) {
-            mHoverView.mScreen.hideTabContentView(mHoverView.mSelectedSectionId, true);
+            mMessageView.disappear(true);
         } else {
-            mHoverView.mScreen.hideTabContentView(mHoverView.mSelectedSectionId, false);
+            mMessageView.disappear(false);
         }
         super.changeState(nextState);
     }
@@ -58,5 +61,16 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     public void collapse() {
         changeState(mHoverView.mCollapsed);
+    }
+
+    @Override
+    protected void activateDragger() {
+        final Rect tabRect = new Rect();
+        final Rect messageRect = new Rect();
+        mFloatingTab.getGlobalVisibleRect(tabRect);
+        mMessageView.getGlobalVisibleRect(messageRect);
+        tabRect.union(messageRect);
+
+        mHoverView.mDragger.activate(mDragListener, tabRect);
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/Screen.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Screen.java
@@ -141,16 +141,7 @@ class Screen {
         return mShadeView;
     }
 
-    public void showTabContentView(final HoverMenu.SectionId sectionId, final SideDock dock, final Runnable onAppeared) {
-        if (getChainedTab(sectionId) != null && mTabMessageViews.get(sectionId.toString()) != null) {
-            mTabMessageViews.get(sectionId.toString()).appear(dock, onAppeared);
-        }
-    }
-
-    public void hideTabContentView(final HoverMenu.SectionId sectionId, final boolean withAnimation) {
-        final TabMessageView tabMessageView = mTabMessageViews.get(sectionId.toString());
-        if (tabMessageView != null) {
-            tabMessageView.disappear(withAnimation);
-        }
+    public TabMessageView getTabMessageView(final HoverMenu.SectionId sectionId) {
+        return mTabMessageViews.get(sectionId.toString());
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/view/InViewDragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/view/InViewDragger.java
@@ -15,7 +15,6 @@
  */
 package io.mattcarroll.hover.view;
 
-import android.graphics.Point;
 import android.graphics.PointF;
 import android.support.annotation.NonNull;
 import android.util.Log;
@@ -34,7 +33,6 @@ public class InViewDragger implements Dragger {
     private static final String TAG = "InViewDragger";
 
     private final ViewGroup mContainer;
-    private final int mTouchAreaDiameter;
     private final int mTapTouchSlop;
     private boolean mIsActivated;
     private boolean mIsDragging;
@@ -98,9 +96,8 @@ public class InViewDragger implements Dragger {
         }
     };
 
-    public InViewDragger(@NonNull ViewGroup container, int touchAreaDiameter, int touchSlop) {
+    public InViewDragger(@NonNull ViewGroup container, int touchSlop) {
         mContainer = container;
-        mTouchAreaDiameter = touchAreaDiameter;
         mTapTouchSlop = touchSlop;
     }
 
@@ -111,12 +108,12 @@ public class InViewDragger implements Dragger {
     }
 
     @Override
-    public void activate(@NonNull DragListener dragListener, @NonNull Point dragStartCenterPosition) {
+    public void activate(@NonNull DragListener dragListener, @NonNull View draggedView) {
         if (!mIsActivated) {
             Log.d(TAG, "Activating.");
             mIsActivated = true;
             mDragListener = dragListener;
-            createTouchControlView(dragStartCenterPosition);
+            createTouchControlView(draggedView);
         }
     }
 
@@ -129,14 +126,15 @@ public class InViewDragger implements Dragger {
         }
     }
 
-    private void createTouchControlView(@NonNull Point dragStartCenterPosition) {
+    private void createTouchControlView(@NonNull View draggedView) {
         mDragView = new View(mContainer.getContext());
         mDragView.setId(R.id.hover_drag_view);
-        mDragView.setLayoutParams(new ViewGroup.LayoutParams(mTouchAreaDiameter, mTouchAreaDiameter));
+        mDragView.setLayoutParams(new ViewGroup.LayoutParams(draggedView.getWidth(), draggedView.getHeight()));
         mDragView.setOnTouchListener(mDragTouchListener);
         mContainer.addView(mDragView);
 
-        moveDragViewTo(new PointF(dragStartCenterPosition.x, dragStartCenterPosition.y));
+        moveDragViewTo(new PointF(draggedView.getX() + (draggedView.getWidth() / 2),
+                draggedView.getY() + (draggedView.getHeight() / 2)));
         updateTouchControlViewAppearance();
     }
 
@@ -179,15 +177,15 @@ public class InViewDragger implements Dragger {
 
     private PointF convertCornerToCenter(@NonNull PointF cornerPosition) {
         return new PointF(
-                cornerPosition.x + (mTouchAreaDiameter / 2),
-                cornerPosition.y + (mTouchAreaDiameter / 2)
+                cornerPosition.x + (mDragView.getWidth() / 2),
+                cornerPosition.y + (mDragView.getHeight() / 2)
         );
     }
 
     private PointF convertCenterToCorner(@NonNull PointF centerPosition) {
         return new PointF(
-                centerPosition.x - (mTouchAreaDiameter / 2),
-                centerPosition.y - (mTouchAreaDiameter / 2)
+                centerPosition.x - (mDragView.getWidth() / 2),
+                centerPosition.y - (mDragView.getHeight() / 2)
         );
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/view/InViewDragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/view/InViewDragger.java
@@ -16,6 +16,7 @@
 package io.mattcarroll.hover.view;
 
 import android.graphics.PointF;
+import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.MotionEvent;
@@ -108,12 +109,12 @@ public class InViewDragger implements Dragger {
     }
 
     @Override
-    public void activate(@NonNull DragListener dragListener, @NonNull View draggedView) {
+    public void activate(@NonNull DragListener dragListener, @NonNull Rect rect) {
         if (!mIsActivated) {
             Log.d(TAG, "Activating.");
             mIsActivated = true;
             mDragListener = dragListener;
-            createTouchControlView(draggedView);
+            createTouchControlView(rect);
         }
     }
 
@@ -126,15 +127,16 @@ public class InViewDragger implements Dragger {
         }
     }
 
-    private void createTouchControlView(@NonNull View draggedView) {
+    private void createTouchControlView(@NonNull Rect rect) {
         mDragView = new View(mContainer.getContext());
         mDragView.setId(R.id.hover_drag_view);
-        mDragView.setLayoutParams(new ViewGroup.LayoutParams(draggedView.getWidth(), draggedView.getHeight()));
+        final int width = rect.right - rect.left;
+        final int height = rect.bottom - rect.top;
+        mDragView.setLayoutParams(new ViewGroup.LayoutParams(width, height));
         mDragView.setOnTouchListener(mDragTouchListener);
         mContainer.addView(mDragView);
 
-        moveDragViewTo(new PointF(draggedView.getX() + (draggedView.getWidth() / 2),
-                draggedView.getY() + (draggedView.getHeight() / 2)));
+        moveDragViewTo(new PointF((rect.right + rect.left) / 2, (rect.bottom + rect.top) / 2));
         updateTouchControlViewAppearance();
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/window/InWindowDragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/window/InWindowDragger.java
@@ -34,7 +34,6 @@ public class InWindowDragger implements Dragger {
 
     private final Context mContext;
     private final WindowViewController mWindowViewController;
-    private final int mTouchAreaDiameter;
     private final float mTapTouchSlop;
     private View mDragView;
     private Dragger.DragListener mDragListener;
@@ -108,24 +107,24 @@ public class InWindowDragger implements Dragger {
      */
     public InWindowDragger(@NonNull Context context,
                            @NonNull WindowViewController windowViewController,
-                           int touchAreaDiameter,
                            float tapTouchSlop) {
         mContext = context;
         mWindowViewController = windowViewController;
-        mTouchAreaDiameter = touchAreaDiameter;
         mTapTouchSlop = tapTouchSlop;
     }
 
-    public void activate(@NonNull DragListener dragListener, @NonNull Point dragStartCenterPosition) {
+    @Override
+    public void activate(@NonNull DragListener dragListener, @NonNull View draggedView) {
         if (!mIsActivated) {
             Log.d(TAG, "Activating.");
-            createTouchControlView(dragStartCenterPosition);
+            createTouchControlView(draggedView);
             mDragListener = dragListener;
             mDragView.setOnTouchListener(mDragTouchListener);
             mIsActivated = true;
         }
     }
 
+    @Override
     public void deactivate() {
         if (mIsActivated) {
             Log.d(TAG, "Deactivating.");
@@ -141,11 +140,10 @@ public class InWindowDragger implements Dragger {
         updateTouchControlViewAppearance();
     }
 
-    private void createTouchControlView(@NonNull final Point dragStartCenterPosition) {
-        // TODO: define dimen size
+    private void createTouchControlView(@NonNull final View draggedView) {
         mDragView = new View(mContext);
-        mWindowViewController.addView(mTouchAreaDiameter, mTouchAreaDiameter, true, mDragView);
-        mWindowViewController.moveViewTo(mDragView, dragStartCenterPosition.x - (mTouchAreaDiameter / 2), dragStartCenterPosition.y - (mTouchAreaDiameter / 2));
+        mWindowViewController.addView(draggedView.getWidth(), draggedView.getHeight(), true, mDragView);
+        mWindowViewController.moveViewTo(mDragView, (int) draggedView.getX(), (int) draggedView.getY());
         mDragView.setOnTouchListener(mDragTouchListener);
 
         updateTouchControlViewAppearance();

--- a/hover/src/main/java/io/mattcarroll/hover/window/InWindowDragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/window/InWindowDragger.java
@@ -18,6 +18,7 @@ package io.mattcarroll.hover.window;
 import android.content.Context;
 import android.graphics.Point;
 import android.graphics.PointF;
+import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.MotionEvent;
@@ -114,10 +115,10 @@ public class InWindowDragger implements Dragger {
     }
 
     @Override
-    public void activate(@NonNull DragListener dragListener, @NonNull View draggedView) {
+    public void activate(@NonNull DragListener dragListener, @NonNull Rect rect) {
         if (!mIsActivated) {
             Log.d(TAG, "Activating.");
-            createTouchControlView(draggedView);
+            createTouchControlView(rect);
             mDragListener = dragListener;
             mDragView.setOnTouchListener(mDragTouchListener);
             mIsActivated = true;
@@ -140,10 +141,12 @@ public class InWindowDragger implements Dragger {
         updateTouchControlViewAppearance();
     }
 
-    private void createTouchControlView(@NonNull final View draggedView) {
+    private void createTouchControlView(@NonNull Rect rect) {
         mDragView = new View(mContext);
-        mWindowViewController.addView(draggedView.getWidth(), draggedView.getHeight(), true, mDragView);
-        mWindowViewController.moveViewTo(mDragView, (int) draggedView.getX(), (int) draggedView.getY());
+        final int width = rect.right - rect.left;
+        final int height = rect.bottom - rect.top;
+        mWindowViewController.addView(width, height, true, mDragView);
+        mWindowViewController.moveViewTo(mDragView, rect.left, rect.top);
         mDragView.setOnTouchListener(mDragTouchListener);
 
         updateTouchControlViewAppearance();


### PR DESCRIPTION
- before : Dragger 는 `Point dragStartCenterPosition` 을 입력받으면 그 주변으로 고정된 크기의(75dp) touchDiameter 만큼의 Drag area 를 만든다.
- after : Drag area 를 Rect 로 만들어서 Dragger 에 넘긴다. Rect 를 만드는 방식은 HoverViewStateCollapsed, HoverViewStatePreviewed 마다 각각 다르다.