### PR TITLE
Preview가 시간이 다 되어 닫힐때 사용자가 Drag를 하고있을 경우 exit view가 계속 표시되는 버그 수정

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -178,6 +178,8 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
             mHoverView.mMenu.setUpdatedCallback(null);
         }
 
+        mHoverView.mScreen.getExitView().setVisibility(GONE);
+
         mHasControl = false;
         mIsDocked = false;
         deactivateDragger();


### PR DESCRIPTION
Steps to reproduce:
- Preview state에서 count down이 진행중일 때, Drag 시작
- Count down이 끝나면 자동으로 state이 변환되며 view가 제자리로 돌아감
- 하단의 ExitView는 그대로 표시됨