### PR TITLE
[BZZRWRDD-252] Added 'Anchored' State for not using ContentDisplay, refactor callbacks

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/BaseHoverViewState.java
+++ b/hover/src/main/java/io/mattcarroll/hover/BaseHoverViewState.java
@@ -15,7 +15,9 @@
  */
 package io.mattcarroll.hover;
 
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
  * {@link HoverViewState} that includes behavior common to all implementations.
@@ -25,6 +27,7 @@ abstract class BaseHoverViewState implements HoverViewState {
     private boolean mHasControl = false;
     protected HoverView mHoverView;
 
+    @CallSuper
     @Override
     public void takeControl(@NonNull HoverView hoverView) {
         if (mHasControl) {
@@ -34,6 +37,7 @@ abstract class BaseHoverViewState implements HoverViewState {
         mHoverView = hoverView;
     }
 
+    @CallSuper
     @Override
     public void giveUpControl(@NonNull HoverViewState nextState) {
         if (!mHasControl) {
@@ -43,7 +47,11 @@ abstract class BaseHoverViewState implements HoverViewState {
         mHoverView = null;
     }
 
-    protected boolean hasControl() {
+    protected final boolean hasControl() {
         return mHasControl;
+    }
+
+    @Override
+    public void setMenu(@Nullable HoverMenu menu) {
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/BaseHoverViewState.java
+++ b/hover/src/main/java/io/mattcarroll/hover/BaseHoverViewState.java
@@ -16,63 +16,34 @@
 package io.mattcarroll.hover;
 
 import android.support.annotation.NonNull;
-import android.view.WindowManager;
 
 /**
  * {@link HoverViewState} that includes behavior common to all implementations.
  */
 abstract class BaseHoverViewState implements HoverViewState {
 
-    private HoverView mHoverView;
+    private boolean mHasControl = false;
+    protected HoverView mHoverView;
 
     @Override
     public void takeControl(@NonNull HoverView hoverView) {
+        if (mHasControl) {
+            throw new RuntimeException("Cannot take control of a FloatingTab when we already control one.");
+        }
+        mHasControl = true;
         mHoverView = hoverView;
     }
 
-    // Only call this if using HoverMenuView directly in a window.
     @Override
-    public void addToWindow() {
-        if (!mHoverView.mIsAddedToWindow) {
-            mHoverView.mWindowViewController.addView(
-                    WindowManager.LayoutParams.MATCH_PARENT,
-                    WindowManager.LayoutParams.MATCH_PARENT,
-                    false,
-                    mHoverView
-            );
-
-            mHoverView.mIsAddedToWindow = true;
-
-            if (mHoverView.mIsTouchableInWindow) {
-                mHoverView.makeTouchableInWindow();
-            } else {
-                mHoverView.makeUntouchableInWindow();
-            }
+    public void giveUpControl(@NonNull HoverViewState nextState) {
+        if (!mHasControl) {
+            throw new RuntimeException("Cannot give up control of a FloatingTab when we don't have the control");
         }
+        mHasControl = false;
+        mHoverView = null;
     }
 
-    // Only call this if using HoverMenuView directly in a window.
-    @Override
-    public void removeFromWindow() {
-        if (mHoverView.mIsAddedToWindow) {
-            mHoverView.mWindowViewController.removeView(mHoverView);
-            mHoverView.mIsAddedToWindow = false;
-        }
-    }
-
-    @Override
-    public void makeTouchableInWindow() {
-        mHoverView.mIsTouchableInWindow = true;
-        if (mHoverView.mIsAddedToWindow) {
-            mHoverView.mWindowViewController.makeTouchable(mHoverView);
-        }
-    }
-
-    @Override
-    public void makeUntouchableInWindow() {
-        mHoverView.mIsTouchableInWindow = false;
-        if (mHoverView.mIsAddedToWindow) {
-            mHoverView.mWindowViewController.makeUntouchable(mHoverView);
-        }
+    protected boolean hasControl() {
+        return mHasControl;
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/BaseHoverViewState.java
+++ b/hover/src/main/java/io/mattcarroll/hover/BaseHoverViewState.java
@@ -29,7 +29,7 @@ abstract class BaseHoverViewState implements HoverViewState {
 
     @CallSuper
     @Override
-    public void takeControl(@NonNull HoverView hoverView) {
+    public void takeControl(@NonNull HoverView hoverView, Runnable onStateChanged) {
         if (mHasControl) {
             throw new RuntimeException("Cannot take control of a FloatingTab when we already control one.");
         }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewState.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewState.java
@@ -29,22 +29,7 @@ interface HoverViewState {
      */
     void takeControl(@NonNull HoverView hoverView);
 
-    void preview();
-
-    /**
-     * Expands the HoverView.
-     */
-    void expand();
-
-    /**
-     * Collapses the HoverView.
-     */
-    void collapse();
-
-    /**
-     * Closes the HoverView (no menu or tabs are visible).
-     */
-    void close();
+    void giveUpControl(@NonNull HoverViewState nextState);
 
     /**
      * Displays the given {@code menu} within the HoverView.
@@ -63,26 +48,4 @@ interface HoverViewState {
      * {@link #respondsToBackButton()} returns true.
      */
     void onBackPressed();
-
-    /**
-     * Adds the HoverView to the Android device's Window.
-     */
-    void addToWindow();
-
-    /**
-     * Removes the HoverView from the Android device's Window.
-     */
-    void removeFromWindow();
-
-    /**
-     * Assuming that the HoverView is added to the Android device's Window, makes the HoverView
-     * touchable.
-     */
-    void makeTouchableInWindow();
-
-    /**
-     * Assuming that the HoverView is added to the Android device's Window, makes the HoverView
-     * untouchable (touch events pass through the overlay to whatever is beneath).
-     */
-    void makeUntouchableInWindow();
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewState.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewState.java
@@ -26,8 +26,9 @@ interface HoverViewState {
     /**
      * Activates this state.
      * @param hoverView hoverView
+     * @param onStateChanged Runnable to be run after state has changed
      */
-    void takeControl(@NonNull HoverView hoverView);
+    void takeControl(@NonNull HoverView hoverView, Runnable onStateChanged);
 
     void giveUpControl(@NonNull HoverViewState nextState);
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateAnchored.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateAnchored.java
@@ -14,8 +14,8 @@ public class HoverViewStateAnchored extends BaseHoverViewState {
     private Point mDock;
 
     @Override
-    public void takeControl(@NonNull HoverView hoverView) {
-        super.takeControl(hoverView);
+    public void takeControl(@NonNull HoverView hoverView, final Runnable onStateChanged) {
+        super.takeControl(hoverView, onStateChanged);
         Log.d(TAG, "Taking control.");
         mHoverView.makeUntouchableInWindow();
         mHoverView.clearFocus();
@@ -33,7 +33,7 @@ public class HoverViewStateAnchored extends BaseHoverViewState {
                 if (!hasControl()) {
                     return;
                 }
-                mHoverView.notifyListenersAnchored();
+                onStateChanged.run();
             }
         });
     }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateAnchored.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateAnchored.java
@@ -1,0 +1,55 @@
+package io.mattcarroll.hover;
+
+import android.graphics.Point;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+public class HoverViewStateAnchored extends BaseHoverViewState {
+
+    private static final String TAG = "HoverViewStateAnchored";
+    private static final int ANCHOR_TAB_X_OFFSET_IN_PX = 100;
+    private static final int ANCHOR_TAB_Y_OFFSET_IN_PX = 100;
+
+    private FloatingTab mSelectedTab;
+    private Point mDock;
+
+    @Override
+    public void takeControl(@NonNull HoverView hoverView) {
+        super.takeControl(hoverView);
+        Log.d(TAG, "Taking control.");
+        mHoverView.makeUntouchableInWindow();
+        mHoverView.clearFocus();
+        mDock = new Point(
+                mHoverView.mScreen.getWidth() - ANCHOR_TAB_X_OFFSET_IN_PX,
+                ANCHOR_TAB_Y_OFFSET_IN_PX
+        );
+
+        HoverMenu.Section section = mHoverView.mMenu.getSection(0);
+        mSelectedTab = mHoverView.mScreen.createChainedTab(section);
+        mSelectedTab.setDock(new PositionDock(mDock));
+        mSelectedTab.dock(new Runnable() {
+            @Override
+            public void run() {
+                if (!hasControl()) {
+                    return;
+                }
+                mHoverView.notifyListenersAnchored();
+            }
+        });
+    }
+
+    @Override
+    public void giveUpControl(@NonNull HoverViewState nextState) {
+        Log.d(TAG, "Giving up control.");
+        super.giveUpControl(nextState);
+    }
+
+    @Override
+    public boolean respondsToBackButton() {
+        return false;
+    }
+
+    @Override
+    public void onBackPressed() {
+    }
+}

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
@@ -28,8 +28,8 @@ class HoverViewStateClosed extends BaseHoverViewState {
     private static final String TAG = "HoverViewStateClosed";
 
     @Override
-    public void takeControl(@NonNull HoverView hoverView) {
-        super.takeControl(hoverView);
+    public void takeControl(@NonNull HoverView hoverView, final Runnable onStateChanged) {
+        super.takeControl(hoverView, onStateChanged);
         Log.d(TAG, "Taking control.");
         mHoverView.makeUntouchableInWindow();
         mHoverView.clearFocus();
@@ -46,11 +46,11 @@ class HoverViewStateClosed extends BaseHoverViewState {
                     if (null != mHoverView.mOnExitListener) {
                         mHoverView.mOnExitListener.onExit();
                     }
-                    mHoverView.notifyListenersClosed();
+                    onStateChanged.run();
                 }
             });
         } else {
-            mHoverView.notifyListenersClosed();
+            onStateChanged.run();
         }
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
@@ -16,7 +16,6 @@
 package io.mattcarroll.hover;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Log;
 
 /**
@@ -32,7 +31,7 @@ class HoverViewStateClosed extends BaseHoverViewState {
     public void takeControl(@NonNull HoverView hoverView) {
         super.takeControl(hoverView);
         Log.d(TAG, "Taking control.");
-        mHoverView.notifyListenersClosing();
+        mHoverView.makeUntouchableInWindow();
         mHoverView.clearFocus();
 
         final FloatingTab selectedTab = mHoverView.mScreen.getChainedTab(mHoverView.mSelectedSectionId);
@@ -53,24 +52,6 @@ class HoverViewStateClosed extends BaseHoverViewState {
         } else {
             mHoverView.notifyListenersClosed();
         }
-
-        mHoverView.makeUntouchableInWindow();
-    }
-
-    @Override
-    public void setMenu(@Nullable final HoverMenu menu) {
-        mHoverView.mMenu = menu;
-
-        // If the menu is null then there is nothing to restore.
-        if (null == menu) {
-            return;
-        }
-
-        mHoverView.restoreVisualState();
-
-        if (null == mHoverView.mSelectedSectionId || null == mHoverView.mMenu.getSection(mHoverView.mSelectedSectionId)) {
-            mHoverView.mSelectedSectionId = mHoverView.mMenu.getSection(0).getId();
-        }
     }
 
     @Override
@@ -81,5 +62,11 @@ class HoverViewStateClosed extends BaseHoverViewState {
     @Override
     public void onBackPressed() {
         // No-op
+    }
+
+    @Override
+    public void giveUpControl(@NonNull HoverViewState nextState) {
+        Log.d(TAG, "Giving up control.");
+        super.giveUpControl(nextState);
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
@@ -19,8 +19,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
-import static android.view.View.GONE;
-
 /**
  * {@link HoverViewState} that operates the {@link HoverView} when it is closed. Closed means that
  * nothing is visible - no tabs, no content.  From the user's perspective, there is no
@@ -30,29 +28,19 @@ class HoverViewStateClosed extends BaseHoverViewState {
 
     private static final String TAG = "HoverViewStateClosed";
 
-    private HoverView mHoverView;
-    private boolean mHasControl = false;
-
     @Override
     public void takeControl(@NonNull HoverView hoverView) {
-        Log.d(TAG, "Taking control.");
         super.takeControl(hoverView);
-        if (mHasControl) {
-            throw new RuntimeException("Cannot take control of a FloatingTab when we already control one.");
-        }
-        mHasControl = true;
-        mHoverView = hoverView;
+        Log.d(TAG, "Taking control.");
         mHoverView.notifyListenersClosing();
-        mHoverView.mState = this;
         mHoverView.clearFocus();
-        mHoverView.mScreen.getContentDisplay().setVisibility(GONE);
 
         final FloatingTab selectedTab = mHoverView.mScreen.getChainedTab(mHoverView.mSelectedSectionId);
         if (null != selectedTab) {
             selectedTab.disappear(new Runnable() {
                 @Override
                 public void run() {
-                    if (!mHasControl) {
+                    if (!hasControl()) {
                         return;
                     }
                     mHoverView.mScreen.destroyChainedTab(selectedTab);
@@ -67,50 +55,6 @@ class HoverViewStateClosed extends BaseHoverViewState {
         }
 
         mHoverView.makeUntouchableInWindow();
-    }
-
-    private void changeState(@NonNull HoverViewState nextState) {
-        if (!mHasControl) {
-            throw new RuntimeException("Cannot give control to another HoverMenuController when we don't have the HoverTab.");
-        }
-        mHasControl = false;
-        mHoverView.setState(nextState);
-        mHoverView = null;
-    }
-
-    @Override
-    public void preview() {
-        if (null != mHoverView.mMenu) {
-            Log.d(TAG, "Preview.");
-            changeState(mHoverView.mPreviewed);
-        } else {
-            Log.d(TAG, "Asked to preview, but there is no menu set. Can't preview until a menu is available.");
-        }
-    }
-
-    @Override
-    public void expand() {
-        if (null != mHoverView.mMenu) {
-            Log.d(TAG, "Expanding.");
-            changeState(mHoverView.mExpanded);
-        } else {
-            Log.d(TAG, "Asked to expand, but there is no menu set. Can't expand until a menu is available.");
-        }
-    }
-
-    @Override
-    public void collapse() {
-        if (null != mHoverView.mMenu) {
-            Log.d(TAG, "Collapsing.");
-            changeState(mHoverView.mCollapsed);
-        } else {
-            Log.d(TAG, "Asked to collapse, but there is no menu set. Can't collapse until a menu is available.");
-        }
-    }
-
-    @Override
-    public void close() {
-        Log.d(TAG, "Instructed to close, but Hover is already closed.");
     }
 
     @Override

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -50,7 +50,6 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     private boolean mIsCollapsed = false;
     private boolean mIsDocked = false;
     protected Dragger.DragListener mDragListener;
-    private Listener mListener;
     private Handler mHandler = new Handler();
     private Runnable mAlphaChanger = new Runnable() {
         @Override
@@ -95,9 +94,6 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
         mDragListener = new FloatingTabDragListener(this);
         mIsCollapsed = false; // We're collapsing, not yet collapsed.
-        if (null != mListener) {
-            mListener.onCollapsing();
-        }
         initDockPosition();
 
         // post() animation to dock in case the container hasn't measured itself yet.
@@ -207,25 +203,14 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         // No-op
     }
 
-    public void setListener(@Nullable Listener listener) {
-        mListener = listener;
-    }
-
     private void onPickedUpByUser() {
         mIsDocked = false;
         mHoverView.mScreen.getExitView().setVisibility(VISIBLE);
-        if (null != mListener) {
-            mListener.onDragStart();
-        }
         restoreHoverViewAlphaValue();
     }
 
     private void onDroppedByUser() {
         mHoverView.mScreen.getExitView().setVisibility(GONE);
-        if (null != mListener) {
-            mListener.onDragEnd();
-        }
-
         boolean droppedOnExit = mHoverView.mScreen.getExitView().isInExitZone(mFloatingTab.getPosition());
         if (droppedOnExit) {
             Log.d(TAG, "User dropped floating tab on exit.");
@@ -259,10 +244,8 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
 
     private void onTap() {
         Log.d(TAG, "Floating tab was tapped.");
-        mHoverView.expand();
-        if (null != mListener) {
-            mListener.onTap();
-        }
+//        mHoverView.expand();
+        mHoverView.anchor();
     }
 
     private void sendToDock() {
@@ -310,12 +293,8 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         boolean didJustCollapse = !mIsCollapsed;
         mIsCollapsed = true;
         mHoverView.saveVisualState();
-        if (null != mListener) {
-            if (didJustCollapse) {
-                mHoverView.notifyListenersCollapsed();
-                mListener.onCollapsed();
-            }
-            mListener.onDocked();
+        if (didJustCollapse) {
+            mHoverView.notifyListenersCollapsed();
         }
     }
 
@@ -340,23 +319,6 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     protected void restoreHoverViewAlphaValue() {
         mHandler.removeCallbacks(mAlphaChanger);
         mHoverView.setAlpha(1f);
-    }
-
-    public interface Listener {
-        void onCollapsing();
-
-        void onCollapsed();
-
-        void onDragStart();
-
-        void onDragEnd();
-
-        void onDocked();
-
-        void onTap();
-
-        // TODO: do we need this?
-        void onExited();
     }
 
     protected static final class FloatingTabDragListener implements Dragger.DragListener {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -78,8 +78,8 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     public void takeControl(@NonNull HoverView hoverView) {
         super.takeControl(hoverView);
         Log.d(TAG, "Taking control.");
-        mHoverView.clearFocus(); // For handling hardware back button presses.
         mHoverView.makeUntouchableInWindow();
+        mHoverView.clearFocus(); // For handling hardware back button presses.
 
         Log.d(TAG, "Taking control with selected section: " + mHoverView.mSelectedSectionId);
         mSelectedSection = mHoverView.mMenu.getSection(mHoverView.mSelectedSectionId);
@@ -96,7 +96,6 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mDragListener = new FloatingTabDragListener(this);
         mIsCollapsed = false; // We're collapsing, not yet collapsed.
         if (null != mListener) {
-            mHoverView.notifyListenersCollapsing();
             mListener.onCollapsing();
         }
         initDockPosition();
@@ -152,20 +151,6 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
 
     @Override
     public void setMenu(@Nullable final HoverMenu menu) {
-        mHoverView.mMenu = menu;
-
-        // If the menu is null or empty then we can't be collapsed, close the menu.
-        if (null == menu || menu.getSectionCount() == 0) {
-            mHoverView.close();
-            return;
-        }
-
-        mHoverView.restoreVisualState();
-
-        if (null == mHoverView.mSelectedSectionId || null == mHoverView.mMenu.getSection(mHoverView.mSelectedSectionId)) {
-            mHoverView.mSelectedSectionId = mHoverView.mMenu.getSection(0).getId();
-        }
-
         listenForMenuChanges();
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
@@ -99,8 +99,6 @@ class HoverViewStateExpanded extends BaseHoverViewState {
         } else {
             mSelectedTab.dock(mShowTabsRunnable);
         }
-
-        mHoverView.notifyListenersExpanding();
     }
 
     private void createChainedTabs() {
@@ -238,20 +236,6 @@ class HoverViewStateExpanded extends BaseHoverViewState {
     @Override
     public void setMenu(@Nullable HoverMenu menu) {
         Log.d(TAG, "Setting menu.");
-        mHoverView.mMenu = menu;
-
-        // Expanded menus can't be null/empty.  If it is then go to closed state.
-        if (null == mHoverView.mMenu || mHoverView.mMenu.getSectionCount() == 0) {
-            mHoverView.close();
-            return;
-        }
-
-        mHoverView.restoreVisualState();
-
-        if (null == mHoverView.mSelectedSectionId || null == mHoverView.mMenu.getSection(mHoverView.mSelectedSectionId)) {
-            mHoverView.mSelectedSectionId = mHoverView.mMenu.getSection(0).getId();
-        }
-
         mHoverView.mMenu.setUpdatedCallback(new ListUpdateCallback() {
             @Override
             public void onInserted(int position, int count) {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
@@ -50,7 +50,6 @@ class HoverViewStateExpanded extends BaseHoverViewState {
     private final List<TabChain> mTabChains = new ArrayList<>();
     private final Map<FloatingTab, HoverMenu.Section> mSections = new HashMap<>();
     private Point mDock;
-    private Listener mListener;
     private int mTabsToUnchainCount;
 
     private final Runnable mShowTabsRunnable = new Runnable() {
@@ -65,13 +64,8 @@ class HoverViewStateExpanded extends BaseHoverViewState {
                     ? mHoverView.mMenu.getSection(mHoverView.mSelectedSectionId)
                     : mHoverView.mMenu.getSection(0);
             mHoverView.mScreen.getContentDisplay().displayContent(selectedSection.getContent());
-
             mHoverView.mScreen.getContentDisplay().setVisibility(View.VISIBLE);
-
             mHoverView.notifyListenersExpanded();
-            if (null != mListener) {
-                mListener.onExpanded();
-            }
         }
     };
 
@@ -107,9 +101,6 @@ class HoverViewStateExpanded extends BaseHoverViewState {
         }
 
         mHoverView.notifyListenersExpanding();
-        if (null != mListener) {
-            mListener.onExpanding();
-        }
     }
 
     private void createChainedTabs() {
@@ -479,19 +470,5 @@ class HoverViewStateExpanded extends BaseHoverViewState {
         ContentDisplay contentDisplay = mHoverView.mScreen.getContentDisplay();
         contentDisplay.selectedTabIs(mSelectedTab);
         contentDisplay.displayContent(section.getContent());
-    }
-
-    // TODO: do we need this?
-    public void setListener(@NonNull Listener listener) {
-        mListener = listener;
-    }
-
-    public interface Listener {
-        void onExpanding();
-
-        void onExpanded();
-
-        // TODO: do we need this?
-        void onCollapseRequested();
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
@@ -51,6 +51,7 @@ class HoverViewStateExpanded extends BaseHoverViewState {
     private final Map<FloatingTab, HoverMenu.Section> mSections = new HashMap<>();
     private Point mDock;
     private int mTabsToUnchainCount;
+    private Runnable mOnStateChanged;
 
     private final Runnable mShowTabsRunnable = new Runnable() {
         @Override
@@ -65,14 +66,15 @@ class HoverViewStateExpanded extends BaseHoverViewState {
                     : mHoverView.mMenu.getSection(0);
             mHoverView.mScreen.getContentDisplay().displayContent(selectedSection.getContent());
             mHoverView.mScreen.getContentDisplay().setVisibility(View.VISIBLE);
-            mHoverView.notifyListenersExpanded();
+            mOnStateChanged.run();
         }
     };
 
     @Override
-    public void takeControl(@NonNull HoverView hoverView) {
-        super.takeControl(hoverView);
+    public void takeControl(@NonNull HoverView hoverView, Runnable onStateChanged) {
+        super.takeControl(hoverView, onStateChanged);
         Log.d(TAG, "Taking control.");
+        mOnStateChanged = onStateChanged;
         mHoverView.makeTouchableInWindow();
         mHoverView.requestFocus(); // For handling hardware back button presses.
         mDock = new Point(

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
@@ -59,6 +59,7 @@ class HoverViewStateExpanded extends BaseHoverViewState {
             if (!hasControl()) {
                 return;
             }
+            mHoverView.mScreen.getShadeView().show();
             mHoverView.mScreen.getContentDisplay().selectedTabIs(mSelectedTab);
 
             HoverMenu.Section selectedSection = null != mHoverView.mSelectedSectionId
@@ -183,6 +184,7 @@ class HoverViewStateExpanded extends BaseHoverViewState {
         mHoverView.mScreen.getContentDisplay().selectedTabIs(null);
         mHoverView.mScreen.getContentDisplay().displayContent(null);
         mHoverView.mScreen.getContentDisplay().setVisibility(View.GONE);
+        mHoverView.mScreen.getShadeView().hide();
         unchainTabs(null);
         super.giveUpControl(nextState);
     }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -18,6 +18,7 @@ package io.mattcarroll.hover;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 /**
  * {@link HoverViewState} that operates the {@link HoverView} when it is closed. Closed means that
@@ -32,7 +33,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     public void takeControl(@NonNull HoverView hoverView) {
         super.takeControl(hoverView);
-        mHoverView.notifyListenersPreviewing();
+        Log.d(TAG, "Taking control.");
         mMessageView = mHoverView.mScreen.getTabMessageView(mHoverView.mSelectedSectionId);
         mMessageView.appear(mHoverView.mCollapsedDock, new Runnable() {
             @Override
@@ -44,6 +45,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
     @Override
     public void giveUpControl(@NonNull final HoverViewState nextState) {
+        Log.d(TAG, "Giving up control.");
         if (nextState instanceof HoverViewStateCollapsed) {
             mMessageView.disappear(true);
         } else {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -18,7 +18,6 @@ package io.mattcarroll.hover;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
-import android.util.Log;
 
 /**
  * {@link HoverViewState} that operates the {@link HoverView} when it is closed. Closed means that
@@ -33,7 +32,6 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     public void takeControl(@NonNull HoverView hoverView) {
         super.takeControl(hoverView);
-        mHoverView.mState = this;
         mHoverView.notifyListenersPreviewing();
         mMessageView = mHoverView.mScreen.getTabMessageView(mHoverView.mSelectedSectionId);
         mMessageView.appear(mHoverView.mCollapsedDock, new Runnable() {
@@ -45,23 +43,13 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     }
 
     @Override
-    protected void changeState(@NonNull final HoverViewState nextState) {
+    public void giveUpControl(@NonNull final HoverViewState nextState) {
         if (nextState instanceof HoverViewStateCollapsed) {
             mMessageView.disappear(true);
         } else {
             mMessageView.disappear(false);
         }
-        super.changeState(nextState);
-    }
-
-    @Override
-    public void preview() {
-        Log.d(TAG, "Instructed to preview, but already previewed.");
-    }
-
-    @Override
-    public void collapse() {
-        changeState(mHoverView.mCollapsed);
+        super.giveUpControl(nextState);
     }
 
     @Override

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -31,14 +31,14 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     private TabMessageView mMessageView;
 
     @Override
-    public void takeControl(@NonNull HoverView hoverView) {
-        super.takeControl(hoverView);
+    public void takeControl(@NonNull HoverView hoverView, final Runnable onStateChanged) {
+        super.takeControl(hoverView, onStateChanged);
         Log.d(TAG, "Taking control.");
         mMessageView = mHoverView.mScreen.getTabMessageView(mHoverView.mSelectedSectionId);
         mMessageView.appear(mHoverView.mCollapsedDock, new Runnable() {
             @Override
             public void run() {
-                mHoverView.notifyListenersPreviewed();
+                onStateChanged.run();
             }
         });
     }

--- a/hover/src/main/java/io/mattcarroll/hover/Screen.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Screen.java
@@ -38,12 +38,21 @@ class Screen {
     private ViewGroup mContainer;
     private ContentDisplay mContentDisplay;
     private ExitView mExitView;
+    private ShadeView mShadeView;
     private Map<String, FloatingTab> mTabs = new HashMap<>();
     private Map<String, TabMessageView> mTabMessageViews = new HashMap<>();
     private boolean mIsDebugMode = false;
 
     Screen(@NonNull ViewGroup hoverMenuContainer) {
         mContainer = hoverMenuContainer;
+
+        mShadeView = new ShadeView(mContainer.getContext());
+        mContainer.addView(mShadeView, new WindowManager.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        mShadeView.hideImmediate();
+
         mExitView = new ExitView(mContainer.getContext());
         mContainer.addView(mExitView, new WindowManager.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -126,6 +135,10 @@ class Screen {
 
     public ExitView getExitView() {
         return mExitView;
+    }
+
+    public ShadeView getShadeView() {
+        return mShadeView;
     }
 
     public TabMessageView getTabMessageView(final HoverMenu.SectionId sectionId) {

--- a/hover/src/main/java/io/mattcarroll/hover/Screen.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Screen.java
@@ -38,21 +38,12 @@ class Screen {
     private ViewGroup mContainer;
     private ContentDisplay mContentDisplay;
     private ExitView mExitView;
-    private ShadeView mShadeView;
     private Map<String, FloatingTab> mTabs = new HashMap<>();
     private Map<String, TabMessageView> mTabMessageViews = new HashMap<>();
     private boolean mIsDebugMode = false;
 
     Screen(@NonNull ViewGroup hoverMenuContainer) {
         mContainer = hoverMenuContainer;
-
-        mShadeView = new ShadeView(mContainer.getContext());
-        mContainer.addView(mShadeView, new WindowManager.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-        ));
-        mShadeView.hideImmediate();
-
         mExitView = new ExitView(mContainer.getContext());
         mContainer.addView(mExitView, new WindowManager.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -135,10 +126,6 @@ class Screen {
 
     public ExitView getExitView() {
         return mExitView;
-    }
-
-    public ShadeView getShadeView() {
-        return mShadeView;
     }
 
     public TabMessageView getTabMessageView(final HoverMenu.SectionId sectionId) {


### PR DESCRIPTION
- HoverViewState 변경 로직 리팩토링
    - State 가 변경되면 HoverView -> HoverViewState -> HoverView 이런 식으로 순환하면서 변경 로직을 처리해줘서 알아보기가 힘들었음
    - 각 HoverViewState 는 takeControl, giveUpControl 로직 구현에 신경을 쓰고, State 간의 transition 은 HoverView 에서 전담한다.
    ```java
    // In HoverView
    void setState(@NonNull HoverViewState newState, Runnable onStateChanged) {
	    if (mState != newState) {
	        if (mState != null) {
	            mState.giveUpControl(newState);
	        }
	        mState = newState;
	        mState.takeControl(this, onStateChanged);
	    }
	}
    ```
    - HoverViewState interface 에서 state 의 역할에 맞지 않는 메소드는 제거함

- OnStateChangeListener 에서 아직은 쓰일 일이 없을 것 같기도 하고, 케이스의 구분이 애매해서 ~ing 콜백은 제거하고 ~ed 콜백만 남김

- OnInteractionListener 추가. FloatingTab 과 유저의 인터렉션을 통해 발생하는 이벤트에 대한 콜백. 이번에 액티비티를 띄울 때에도 필요하고, 이후 드래그 중일때 메세지를 보여주는 로직에서도 쓰일 수 있음

- HoverViewStateAnchored 추가. FloatingTab 이 지정된 위치로 고정되는 상태이다.