### PR TITLE
[BZZRWRDD-262] Anchored 일때 Drag없이 터치만 가능하도록 Dragger의 일부를 TouchController 로 분리하고 Window, View 공통 요소 분리

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/BaseTouchController.java
+++ b/hover/src/main/java/io/mattcarroll/hover/BaseTouchController.java
@@ -1,0 +1,85 @@
+package io.mattcarroll.hover;
+
+import android.graphics.PointF;
+import android.graphics.Rect;
+import android.support.annotation.NonNull;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.View;
+
+public abstract class BaseTouchController {
+    private static final String TAG = "BaseTouchController";
+
+    protected View mTouchView;
+    protected TouchListener mTouchListener;
+    protected boolean mIsActivated;
+    private boolean mIsDebugMode;
+
+    private View.OnTouchListener mDragTouchListener = new View.OnTouchListener() {
+        @Override
+        public boolean onTouch(View view, MotionEvent motionEvent) {
+            switch (motionEvent.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    Log.d(TAG, "ACTION_DOWN");
+                    mTouchListener.onPress();
+                    return true;
+                case MotionEvent.ACTION_UP:
+                    Log.d(TAG, "ACTION_UP");
+                    mTouchListener.onTap();
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    };
+
+    public abstract View createTouchView(@NonNull Rect rect);
+
+    public abstract void destroyTouchView(@NonNull View touchView);
+
+    public abstract void moveTouchViewTo(@NonNull View touchView, @NonNull PointF position);
+
+    public void activate(@NonNull TouchListener touchListener, @NonNull Rect rect) {
+        if (!mIsActivated) {
+            Log.d(TAG, "Activating.");
+            mIsActivated = true;
+            mTouchListener = touchListener;
+            mTouchView = createTouchView(rect);
+            moveTouchViewTo(mTouchView, new PointF(rect.left, rect.top));
+            mTouchView.setOnTouchListener(mDragTouchListener);
+
+            updateTouchControlViewAppearance();
+        }
+    }
+
+    public void deactivate() {
+        if (mIsActivated) {
+            Log.d(TAG, "Deactivating.");
+            mTouchView.setOnTouchListener(null);
+            destroyTouchView(mTouchView);
+            mIsActivated = false;
+            mTouchView = null;
+        }
+    }
+
+    public void enableDebugMode(boolean isDebugMode) {
+        mIsDebugMode = isDebugMode;
+        updateTouchControlViewAppearance();
+    }
+
+    private void updateTouchControlViewAppearance() {
+        if (null != mTouchView) {
+            if (mIsDebugMode) {
+                mTouchView.setBackgroundColor(0x44FF0000);
+            } else {
+                mTouchView.setBackgroundColor(0x00000000);
+            }
+        }
+    }
+
+    public interface TouchListener {
+        void onPress();
+
+        void onTap();
+    }
+}

--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -352,21 +352,21 @@ public class HoverView extends RelativeLayout {
         mOnInteractionListeners.remove(onInteractionListener);
     }
 
-    void notifyOnTap() {
+    void notifyOnTap(HoverViewState state) {
         for (OnInteractionListener onInteractionListener : mOnInteractionListeners) {
-            onInteractionListener.onTap();
+            onInteractionListener.onTap(state.getStateType());
         }
     }
 
-    void notifyOnDragStart() {
+    void notifyOnDragStart(HoverViewState state) {
         for (OnInteractionListener onInteractionListener : mOnInteractionListeners) {
-            onInteractionListener.onDragStart();
+            onInteractionListener.onDragStart(state.getStateType());
         }
     }
 
-    void notifyOnDocked() {
+    void notifyOnDocked(HoverViewState state) {
         for (OnInteractionListener onInteractionListener : mOnInteractionListeners) {
-            onInteractionListener.onDocked();
+            onInteractionListener.onDocked(state.getStateType());
         }
     }
 
@@ -608,10 +608,10 @@ public class HoverView extends RelativeLayout {
     }
 
     public interface OnInteractionListener {
-        void onTap();
+        void onTap(HoverViewStateType stateType);
 
-        void onDragStart();
+        void onDragStart(HoverViewStateType stateType);
 
-        void onDocked();
+        void onDocked(HoverViewStateType stateType);
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -232,11 +232,9 @@ public class HoverView extends RelativeLayout {
         persistentState.restore(this, mMenu);
     }
 
-    // TODO: when to call this?
     public void release() {
         Log.d(TAG, "Released.");
         mDragger.deactivate();
-        // TODO: should we also release the screen?
     }
 
     public void enableDebugMode(boolean debugMode) {
@@ -397,6 +395,7 @@ public class HoverView extends RelativeLayout {
         if (mIsAddedToWindow) {
             mWindowViewController.removeView(this);
             mIsAddedToWindow = false;
+            release();
         }
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewState.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewState.java
@@ -49,4 +49,6 @@ interface HoverViewState {
      * {@link #respondsToBackButton()} returns true.
      */
     void onBackPressed();
+
+    HoverViewStateType getStateType();
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateAnchored.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateAnchored.java
@@ -5,7 +5,7 @@ import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
-public class HoverViewStateAnchored extends BaseHoverViewState {
+class HoverViewStateAnchored extends BaseHoverViewState {
 
     private static final String TAG = "HoverViewStateAnchored";
 
@@ -18,7 +18,7 @@ public class HoverViewStateAnchored extends BaseHoverViewState {
 
         @Override
         public void onTap() {
-            mHoverView.collapse();
+            mHoverView.notifyOnTap(HoverViewStateAnchored.this);
         }
     };
 
@@ -79,5 +79,10 @@ public class HoverViewStateAnchored extends BaseHoverViewState {
 
     @Override
     public void onBackPressed() {
+    }
+
+    @Override
+    public HoverViewStateType getStateType() {
+        return HoverViewStateType.ANCHORED;
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateAnchored.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateAnchored.java
@@ -1,16 +1,16 @@
 package io.mattcarroll.hover;
 
 import android.graphics.Point;
+import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
 public class HoverViewStateAnchored extends BaseHoverViewState {
 
     private static final String TAG = "HoverViewStateAnchored";
-    private static final int ANCHOR_TAB_X_OFFSET_IN_PX = 100;
-    private static final int ANCHOR_TAB_Y_OFFSET_IN_PX = 100;
 
     private FloatingTab mSelectedTab;
+    private HoverMenu.Section mSelectedSection;
     private Point mDock;
 
     @Override
@@ -19,13 +19,20 @@ public class HoverViewStateAnchored extends BaseHoverViewState {
         Log.d(TAG, "Taking control.");
         mHoverView.makeUntouchableInWindow();
         mHoverView.clearFocus();
+        final int pointMargin = hoverView.getContext().getResources().getDimensionPixelSize(R.dimen.hover_tab_anchor_margin);
         mDock = new Point(
-                mHoverView.mScreen.getWidth() - ANCHOR_TAB_X_OFFSET_IN_PX,
-                ANCHOR_TAB_Y_OFFSET_IN_PX
+                mHoverView.mScreen.getWidth() - pointMargin,
+                mHoverView.mScreen.getHeight() - pointMargin
         );
 
-        HoverMenu.Section section = mHoverView.mMenu.getSection(0);
-        mSelectedTab = mHoverView.mScreen.createChainedTab(section);
+        mSelectedSection = mHoverView.mMenu.getSection(mHoverView.mSelectedSectionId);
+        if (mSelectedSection == null) {
+            mSelectedSection = mHoverView.mMenu.getSection(0);
+        }
+        mSelectedTab = mHoverView.mScreen.getChainedTab(mSelectedSection.getId());
+        if (mSelectedTab == null) {
+            mSelectedTab = mHoverView.mScreen.createChainedTab(mSelectedSection);
+        }
         mSelectedTab.setDock(new PositionDock(mDock));
         mSelectedTab.dock(new Runnable() {
             @Override

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
@@ -69,4 +69,9 @@ class HoverViewStateClosed extends BaseHoverViewState {
         Log.d(TAG, "Giving up control.");
         super.giveUpControl(nextState);
     }
+
+    @Override
+    public HoverViewStateType getStateType() {
+        return HoverViewStateType.CLOSED;
+    }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -331,9 +331,6 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
 
         @Override
-        public void onPress(float x, float y) { }
-
-        @Override
         public void onDragStart(float x, float y) {
             mOwner.onPickedUpByUser();
         }
@@ -346,6 +343,10 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         @Override
         public void onReleasedAt(float x, float y) {
             mOwner.onDroppedByUser();
+        }
+
+        @Override
+        public void onPress() {
         }
 
         @Override

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -207,7 +207,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mIsDocked = false;
         mHoverView.mScreen.getExitView().setVisibility(VISIBLE);
         restoreHoverViewAlphaValue();
-        mHoverView.notifyOnDragStart();
+        mHoverView.notifyOnDragStart(this);
     }
 
     private void onDroppedByUser() {
@@ -245,7 +245,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
 
     private void onTap() {
         Log.d(TAG, "Floating tab was tapped.");
-        mHoverView.notifyOnTap();
+        mHoverView.notifyOnTap(this);
     }
 
     private void sendToDock() {
@@ -296,7 +296,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         if (didJustCollapse) {
             mOnStateChanged.run();
         }
-        mHoverView.notifyOnDocked();
+        mHoverView.notifyOnDocked(this);
     }
 
     protected void moveTabTo(@NonNull Point position) {
@@ -320,6 +320,11 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     protected void restoreHoverViewAlphaValue() {
         mHandler.removeCallbacks(mAlphaChanger);
         mHoverView.setAlpha(1f);
+    }
+
+    @Override
+    public HoverViewStateType getStateType() {
+        return HoverViewStateType.COLLAPSED;
     }
 
     protected static final class FloatingTabDragListener implements Dragger.DragListener {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateExpanded.java
@@ -459,4 +459,9 @@ class HoverViewStateExpanded extends BaseHoverViewState {
         contentDisplay.selectedTabIs(mSelectedTab);
         contentDisplay.displayContent(section.getContent());
     }
+
+    @Override
+    public HoverViewStateType getStateType() {
+        return HoverViewStateType.EXPANDED;
+    }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -74,4 +74,9 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
         mHoverView.mDragger.activate(mDragListener, tabRect);
     }
+
+    @Override
+    public HoverViewStateType getStateType() {
+        return HoverViewStateType.PREVIEWED;
+    }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateType.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateType.java
@@ -1,0 +1,9 @@
+package io.mattcarroll.hover;
+
+public enum HoverViewStateType {
+    CLOSED,
+    COLLAPSED,
+    PREVIEWED,
+    EXPANDED,
+    ANCHORED,
+}

--- a/hover/src/main/java/io/mattcarroll/hover/view/InViewDragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/view/InViewDragger.java
@@ -18,8 +18,6 @@ package io.mattcarroll.hover.view;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
-import android.util.Log;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -29,165 +27,43 @@ import io.mattcarroll.hover.R;
 /**
  * {@link Dragger} implementation that works within a {@link ViewGroup}.
  */
-public class InViewDragger implements Dragger {
-
+public class InViewDragger extends Dragger {
     private static final String TAG = "InViewDragger";
 
     private final ViewGroup mContainer;
-    private final int mTapTouchSlop;
-    private boolean mIsActivated;
-    private boolean mIsDragging;
-    private boolean mIsDebugMode = false;
-    private View mDragView;
-    private DragListener mDragListener;
-    private PointF mOriginalViewPosition = new PointF();
-    private PointF mCurrentViewPosition = new PointF();
-    private PointF mOriginalTouchPosition = new PointF();
-
-    private final View.OnTouchListener mDragTouchListener = new View.OnTouchListener() {
-        @Override
-        public boolean onTouch(View view, MotionEvent motionEvent) {
-            switch (motionEvent.getAction()) {
-                case MotionEvent.ACTION_DOWN:
-                    Log.d(TAG, "ACTION_DOWN");
-                    mIsDragging = false;
-
-                    mOriginalViewPosition = getDragViewCenterPosition();
-                    mCurrentViewPosition = new PointF(mOriginalViewPosition.x, mOriginalViewPosition.y);
-                    mOriginalTouchPosition.set(motionEvent.getRawX(), motionEvent.getRawY());
-
-                    mDragListener.onPress(mCurrentViewPosition.x, mCurrentViewPosition.y);
-
-                    return true;
-                case MotionEvent.ACTION_MOVE:
-                    Log.v(TAG, "ACTION_MOVE. motionX: " + motionEvent.getRawX() + ", motionY: " + motionEvent.getRawY());
-                    float dragDeltaX = motionEvent.getRawX() - mOriginalTouchPosition.x;
-                    float dragDeltaY = motionEvent.getRawY() - mOriginalTouchPosition.y;
-                    mCurrentViewPosition = new PointF(
-                            mOriginalViewPosition.x + dragDeltaX,
-                            mOriginalViewPosition.y + dragDeltaY
-                    );
-
-                    if (mIsDragging || !isTouchWithinSlopOfOriginalTouch(dragDeltaX, dragDeltaY)) {
-                        if (!mIsDragging) {
-                            // Dragging just started
-                            Log.d(TAG, "MOVE Start Drag.");
-                            mIsDragging = true;
-                            mDragListener.onDragStart(mCurrentViewPosition.x, mCurrentViewPosition.y);
-                        } else {
-                            moveDragViewTo(mCurrentViewPosition);
-                            mDragListener.onDragTo(mCurrentViewPosition.x, mCurrentViewPosition.y);
-                        }
-                    }
-
-                    return true;
-                case MotionEvent.ACTION_UP:
-                    if (!mIsDragging) {
-                        Log.d(TAG, "ACTION_UP: Tap.");
-                        mDragListener.onTap();
-                    } else {
-                        Log.d(TAG, "ACTION_UP: Released from dragging.");
-                        mDragListener.onReleasedAt(mCurrentViewPosition.x, mCurrentViewPosition.y);
-                    }
-
-                    return true;
-                default:
-                    return false;
-            }
-        }
-    };
 
     public InViewDragger(@NonNull ViewGroup container, int touchSlop) {
+        super(touchSlop);
         mContainer = container;
-        mTapTouchSlop = touchSlop;
     }
 
     @Override
-    public void enableDebugMode(boolean isDebugMode) {
-        mIsDebugMode = isDebugMode;
-        updateTouchControlViewAppearance();
-    }
-
-    @Override
-    public void activate(@NonNull DragListener dragListener, @NonNull Rect rect) {
-        if (!mIsActivated) {
-            Log.d(TAG, "Activating.");
-            mIsActivated = true;
-            mDragListener = dragListener;
-            createTouchControlView(rect);
-        }
-    }
-
-    @Override
-    public void deactivate() {
-        if (mIsActivated) {
-            Log.d(TAG, "Deactivating.");
-            mIsActivated = false;
-            destroyTouchControlView();
-        }
-    }
-
-    private void createTouchControlView(@NonNull Rect rect) {
-        mDragView = new View(mContainer.getContext());
-        mDragView.setId(R.id.hover_drag_view);
+    public View createTouchView(@NonNull Rect rect) {
+        View dragView = new View(mContainer.getContext());
+        dragView.setId(R.id.hover_drag_view);
         final int width = rect.right - rect.left;
         final int height = rect.bottom - rect.top;
-        mDragView.setLayoutParams(new ViewGroup.LayoutParams(width, height));
-        mDragView.setOnTouchListener(mDragTouchListener);
-        mContainer.addView(mDragView);
-
-        moveDragViewTo(new PointF((rect.right + rect.left) / 2, (rect.bottom + rect.top) / 2));
-        updateTouchControlViewAppearance();
+        dragView.setLayoutParams(new ViewGroup.LayoutParams(width, height));
+        mContainer.addView(dragView);
+        return dragView;
     }
 
-    private void destroyTouchControlView() {
-        mContainer.removeView(mDragView);
-
-        mDragView.setOnTouchListener(null);
-        mDragView = null;
+    @Override
+    public void destroyTouchView(@NonNull View touchView) {
+        mContainer.removeView(touchView);
     }
 
-    private void updateTouchControlViewAppearance() {
-        if (null != mDragView) {
-            if (mIsDebugMode) {
-                Log.d(TAG, "Making mDragView red: " + mDragView.hashCode());
-                mDragView.setBackgroundColor(0x44FF0000);
-            } else {
-                mDragView.setBackgroundColor(0x00000000);
-            }
-        }
-    }
-
-    private boolean isTouchWithinSlopOfOriginalTouch(float dx, float dy) {
-        double distance = Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2));
-        return distance < mTapTouchSlop;
-    }
-
-    private PointF getDragViewCenterPosition() {
-        return convertCornerToCenter(new PointF(
-                mDragView.getX(),
-                mDragView.getY()
-        ));
-    }
-
-    private void moveDragViewTo(PointF centerPosition) {
-        Log.d(TAG, "Moving drag view (" + mDragView.hashCode() + ") to: " + centerPosition);
-        PointF cornerPosition = convertCenterToCorner(centerPosition);
-        mDragView.setX(cornerPosition.x);
-        mDragView.setY(cornerPosition.y);
-    }
-
-    private PointF convertCornerToCenter(@NonNull PointF cornerPosition) {
+    @Override
+    public PointF getTouchViewPosition(@NonNull View touchView) {
         return new PointF(
-                cornerPosition.x + (mDragView.getWidth() / 2),
-                cornerPosition.y + (mDragView.getHeight() / 2)
+                touchView.getX(),
+                touchView.getY()
         );
     }
 
-    private PointF convertCenterToCorner(@NonNull PointF centerPosition) {
-        return new PointF(
-                centerPosition.x - (mDragView.getWidth() / 2),
-                centerPosition.y - (mDragView.getHeight() / 2)
-        );
+    @Override
+    public void moveTouchViewTo(@NonNull View touchView, @NonNull PointF position) {
+        touchView.setX(position.x);
+        touchView.setY(position.y);
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/window/InWindowDragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/window/InWindowDragger.java
@@ -16,12 +16,9 @@
 package io.mattcarroll.hover.window;
 
 import android.content.Context;
-import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
-import android.util.Log;
-import android.view.MotionEvent;
 import android.view.View;
 
 import io.mattcarroll.hover.Dragger;
@@ -29,176 +26,41 @@ import io.mattcarroll.hover.Dragger;
 /**
  * {@link Dragger} implementation that works within a {@code Window}.
  */
-public class InWindowDragger implements Dragger {
-
+public class InWindowDragger extends Dragger {
     private static final String TAG = "InWindowDragger";
 
     private final Context mContext;
     private final WindowViewController mWindowViewController;
-    private final float mTapTouchSlop;
-    private View mDragView;
-    private Dragger.DragListener mDragListener;
-    private boolean mIsActivated;
-    private boolean mIsDragging;
-    private boolean mIsDebugMode;
 
-    private PointF mOriginalViewPosition = new PointF();
-    private PointF mCurrentViewPosition = new PointF();
-    private PointF mOriginalTouchPosition = new PointF();
-
-    private View.OnTouchListener mDragTouchListener = new View.OnTouchListener() {
-        @Override
-        public boolean onTouch(View view, MotionEvent motionEvent) {
-            switch (motionEvent.getAction()) {
-                case MotionEvent.ACTION_DOWN:
-                    Log.d(TAG, "ACTION_DOWN");
-                    mIsDragging = false;
-
-                    mOriginalViewPosition = getDragViewCenterPosition();
-                    mCurrentViewPosition = new PointF(mOriginalViewPosition.x, mOriginalViewPosition.y);
-                    mOriginalTouchPosition.set(motionEvent.getRawX(), motionEvent.getRawY());
-
-                    mDragListener.onPress(mCurrentViewPosition.x, mCurrentViewPosition.y);
-
-                    return true;
-                case MotionEvent.ACTION_MOVE:
-                    Log.d(TAG, "ACTION_MOVE. motionX: " + motionEvent.getRawX() + ", motionY: " + motionEvent.getRawY());
-                    float dragDeltaX = motionEvent.getRawX() - mOriginalTouchPosition.x;
-                    float dragDeltaY = motionEvent.getRawY() - mOriginalTouchPosition.y;
-                    mCurrentViewPosition = new PointF(
-                            mOriginalViewPosition.x + dragDeltaX,
-                            mOriginalViewPosition.y + dragDeltaY
-                    );
-
-                    if (mIsDragging || !isTouchWithinSlopOfOriginalTouch(dragDeltaX, dragDeltaY)) {
-                        if (!mIsDragging) {
-                            // Dragging just started
-                            Log.d(TAG, "MOVE Start Drag.");
-                            mIsDragging = true;
-                            mDragListener.onDragStart(mCurrentViewPosition.x, mCurrentViewPosition.y);
-                        } else {
-                            moveDragViewTo(mCurrentViewPosition);
-                            mDragListener.onDragTo(mCurrentViewPosition.x, mCurrentViewPosition.y);
-                        }
-                    }
-
-                    return true;
-                case MotionEvent.ACTION_UP:
-                    Log.d(TAG, "ACTION_UP");
-                    if (!mIsDragging) {
-                        Log.d(TAG, "Reporting as a tap.");
-                        mDragListener.onTap();
-                    } else {
-                        Log.d(TAG, "Reporting as a drag release at: " + mCurrentViewPosition);
-                        mDragListener.onReleasedAt(mCurrentViewPosition.x, mCurrentViewPosition.y);
-                    }
-
-                    return true;
-                default:
-                    return false;
-            }
-        }
-    };
-
-    /**
-     * Note: {@code view} must already be added to the {@code Window}.
-     * @param context context
-     * @param windowViewController windowViewController
-     * @param tapTouchSlop tapTouchSlop
-     */
     public InWindowDragger(@NonNull Context context,
                            @NonNull WindowViewController windowViewController,
-                           float tapTouchSlop) {
+                           int tapTouchSlop) {
+        super(tapTouchSlop);
         mContext = context;
         mWindowViewController = windowViewController;
-        mTapTouchSlop = tapTouchSlop;
     }
 
     @Override
-    public void activate(@NonNull DragListener dragListener, @NonNull Rect rect) {
-        if (!mIsActivated) {
-            Log.d(TAG, "Activating.");
-            createTouchControlView(rect);
-            mDragListener = dragListener;
-            mDragView.setOnTouchListener(mDragTouchListener);
-            mIsActivated = true;
-        }
-    }
-
-    @Override
-    public void deactivate() {
-        if (mIsActivated) {
-            Log.d(TAG, "Deactivating.");
-            mDragView.setOnTouchListener(null);
-            destroyTouchControlView();
-            mIsActivated = false;
-        }
-    }
-
-    @Override
-    public void enableDebugMode(boolean isDebugMode) {
-        mIsDebugMode = isDebugMode;
-        updateTouchControlViewAppearance();
-    }
-
-    private void createTouchControlView(@NonNull Rect rect) {
-        mDragView = new View(mContext);
+    public View createTouchView(@NonNull Rect rect) {
+        View dragView = new View(mContext);
         final int width = rect.right - rect.left;
         final int height = rect.bottom - rect.top;
-        mWindowViewController.addView(width, height, true, mDragView);
-        mWindowViewController.moveViewTo(mDragView, rect.left, rect.top);
-        mDragView.setOnTouchListener(mDragTouchListener);
-
-        updateTouchControlViewAppearance();
+        mWindowViewController.addView(width, height, true, dragView);
+        return dragView;
     }
 
-    private void destroyTouchControlView() {
-        mWindowViewController.removeView(mDragView);
-        mDragView = null;
+    @Override
+    public void destroyTouchView(@NonNull View touchView) {
+        mWindowViewController.removeView(touchView);
     }
 
-    private void updateTouchControlViewAppearance() {
-        if (null != mDragView) {
-            if (mIsDebugMode) {
-                mDragView.setBackgroundColor(0x44FF0000);
-            } else {
-                mDragView.setBackgroundColor(0x00000000);
-            }
-        }
+    @Override
+    public PointF getTouchViewPosition(@NonNull View touchView) {
+        return new PointF(mWindowViewController.getViewPosition(touchView));
     }
 
-    private boolean isTouchWithinSlopOfOriginalTouch(float dx, float dy) {
-        double distance = Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2));
-        Log.d(TAG, "Drag distance " + distance + " vs slop allowance " + mTapTouchSlop);
-        return distance < mTapTouchSlop;
-    }
-
-    private PointF getDragViewCenterPosition() {
-        Point cornerPosition = mWindowViewController.getViewPosition(mDragView);
-        return convertCornerToCenter(new PointF(
-                cornerPosition.x,
-                cornerPosition.y
-        ));
-    }
-
-    private void moveDragViewTo(PointF centerPosition) {
-        Log.d(TAG, "Center position: " + centerPosition);
-        PointF cornerPosition = convertCenterToCorner(centerPosition);
-        Log.d(TAG, "Corner position: " + cornerPosition);
-        mWindowViewController.moveViewTo(mDragView, (int) cornerPosition.x, (int) cornerPosition.y);
-    }
-
-    private PointF convertCornerToCenter(@NonNull PointF cornerPosition) {
-        return new PointF(
-                cornerPosition.x + (mDragView.getWidth() / 2),
-                cornerPosition.y + (mDragView.getHeight() / 2)
-        );
-    }
-
-    private PointF convertCenterToCorner(@NonNull PointF centerPosition) {
-        return new PointF(
-                centerPosition.x - (mDragView.getWidth() / 2),
-                centerPosition.y - (mDragView.getHeight() / 2)
-        );
+    @Override
+    public void moveTouchViewTo(@NonNull View touchView, @NonNull PointF position) {
+        mWindowViewController.moveViewTo(touchView, (int) position.x, (int) position.y);
     }
 }

--- a/hover/src/main/res/values/dimens.xml
+++ b/hover/src/main/res/values/dimens.xml
@@ -6,4 +6,5 @@
     <dimen name="hover_exit_radius">75dp</dimen>
     <dimen name="hover_message_animate_translation_x">32dp</dimen>
     <dimen name="hover_message_animate_translation_y">24dp</dimen>
+    <dimen name="hover_tab_anchor_margin">32dp</dimen>
 </resources>


### PR DESCRIPTION
문제 상황
- HoverView 를 윈도우에 붙일 때 처음부터 스크린의 전체 영역으로 붙이기 때문에 WindowManager 에서 특정 뷰만 집어내어 touchable 하게 바꾸기에는 어려운 구조
- 기존의 Dragger 는 FloatingTab 의 위치에 Drag 가능한 커버 뷰를 새로 만들어서 붙이는데, Dragger 에서 DragStart 뿐만 아니라 Tap, Press 등의 성격이 다른 이벤트도 같이 처리하고 있다.
- 지금 필요한 기능은 Dragger 에서 '커버 뷰가 실제로 Draggable 한' 피쳐를 제거하고, Tap, Press 이벤트만을 받는 것이다.

변경 내용
- Dragger 에서 위와 같이 기본 기능을 분리해 내기 위해 먼저 InWindowDragger 와 InViewDragger 에서 변경이 필요한 부분만 인터페이스로 분리하고, 나머지 공통 기능은 Dragger 에서 직접 구현하도록 리팩토링 (Dragger 를 interface 에서 abstract class 로 변경)
- Dragger 에서 Touch 관련된 기능만 분리해서 그걸 `BaseTouchController` 로 이름짓고 Dragger 가 이를 상속받아서 본래의 dragger 기능으로 확장시키도록 함. 
- 최종적인 클래스 간의 의존 관계는 다음과 같다
    - BaseTouchController
        - <- Dragger
            - <- InWindowDragger
            - <- InViewDragger
- HoverViewStateAnchored 에서 takeControl 이 불릴 때에는 Collapsed 와 다르게 BaseTouchController.TouchListener 를 넘겨, BaseTouchController 의 기능만 activate 되도록 함
- `HoverView#OnInteractionListener` 의 onTap 이 어느 state 에서 발생하였는지 알게 하기 위하여 해당 메소드에 현재 State 의 Type 을 표시하는 enum 을 넘김 (`HoverViewStateType`)