### PR TITLE
Preview 모드에서 MessageView UI가 업데이트 되지 않던 현상 수정

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -47,7 +47,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
 
     protected FloatingTab mFloatingTab;
     protected final Dragger.DragListener mDragListener = new FloatingTabDragListener(this);
-    private HoverMenu.Section mSelectedSection;
+    protected HoverMenu.Section mSelectedSection;
     private int mSelectedSectionIndex = -1;
     private boolean mIsCollapsed = false;
     private boolean mIsDocked = false;

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -37,6 +37,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
         super.takeControl(hoverView, null);
         Log.d(TAG, "Taking control.");
         mMessageView = mHoverView.mScreen.getTabMessageView(mHoverView.mSelectedSectionId);
+        mMessageView.setMessageView(mSelectedSection.getTabMessageView());
         mMessageView.appear(mHoverView.mCollapsedDock, new Runnable() {
             @Override
             public void run() {

--- a/hover/src/main/java/io/mattcarroll/hover/Screen.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Screen.java
@@ -79,11 +79,11 @@ class Screen {
     @NonNull
     public FloatingTab createChainedTab(@NonNull HoverMenu.Section section) {
         String tabId = section.getId().toString();
-        return createChainedTab(tabId, section.getTabView(), section.getTabMessageView());
+        return createChainedTab(tabId, section.getTabView());
     }
 
     @NonNull
-    public FloatingTab createChainedTab(@NonNull String tabId, @NonNull View tabView, @Nullable View tabMessageView) {
+    public FloatingTab createChainedTab(@NonNull String tabId, @NonNull View tabView) {
         Log.d(TAG, "Existing tabs...");
         for (String existingTabId : mTabs.keySet()) {
             Log.d(TAG, existingTabId);
@@ -97,11 +97,9 @@ class Screen {
             chainedTab.enableDebugMode(mIsDebugMode);
             mContainer.addView(chainedTab);
             mTabs.put(tabId, chainedTab);
-            if (tabMessageView != null) {
-                final TabMessageView messageView = new TabMessageView(tabView.getContext(), tabMessageView, chainedTab);
-                mContainer.addView(messageView);
-                mTabMessageViews.put(tabId, messageView);
-            }
+            final TabMessageView messageView = new TabMessageView(tabView.getContext(), chainedTab);
+            mContainer.addView(messageView);
+            mTabMessageViews.put(tabId, messageView);
             return chainedTab;
         }
     }
@@ -119,6 +117,7 @@ class Screen {
 
     public void destroyChainedTab(@NonNull FloatingTab chainedTab) {
         mTabs.remove(chainedTab.getTabId());
+        mTabMessageViews.remove(chainedTab.getTabId());
         chainedTab.setTabView(null);
         mContainer.removeView(chainedTab);
     }

--- a/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
@@ -17,6 +17,7 @@ public class TabMessageView extends HoverFrameLayout {
 
     private final FloatingTab mFloatingTab;
     private SideDock mSideDock;
+    private View mMessageView;
 
     private final OnPositionChangeListener mOnTabPositionChangeListener = new OnPositionChangeListener() {
         @Override
@@ -46,13 +47,23 @@ public class TabMessageView extends HoverFrameLayout {
         }
     };
 
-    public TabMessageView(@NonNull Context context, @NonNull View messageView, @NonNull FloatingTab floatingTab) {
+    public TabMessageView(@NonNull Context context, @NonNull FloatingTab floatingTab) {
         super(context);
         setClipToPadding(false);
         setClipChildren(false);
         mFloatingTab = floatingTab;
-        addView(messageView);
         setVisibility(GONE);
+    }
+
+    public void setMessageView(@Nullable View view) {
+        if (view == mMessageView) {
+            return;
+        }
+        removeAllViews();
+        mMessageView = view;
+        if (mMessageView != null) {
+            addView(mMessageView);
+        }
     }
 
     public void appear(final SideDock dock, @Nullable final Runnable onAppeared) {


### PR DESCRIPTION
- 현상
    - 기존에는 TabMessageView가 한번 뜬 이후에는 Service 가 종료되기 전까지 그 뷰를 다시 보여줄 일이 없었는데 PopControlService 를 Foreground 로 변경하면서 한 서비스 생명주기 내에서 TabMessageView 를 재사용하게 되었습니다. 분명히 업데이트가 필요할 때 새로운 Menu, Section 내에 새로운 MessageView 를 생성해서 넘겼음에도 불구하고 UI가 변경되지 않아서 디버깅 해보았더니 MessageView 가 한번 고정된 UI 에서 더이상 변화할 수 없는 상태였습니다.
- 해결
    - Preview State 로 변할 때마다 항상 최신의 MessageView 를 가져와서 보여줄 수 있도록 변경