### PR TITLE
[BZZRWRDD-280] Docked 여부와 상관 없이 Orientation Changed 가 불리면 FloatingTab 을 정상 위치로 이동

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/FloatingTab.java
+++ b/hover/src/main/java/io/mattcarroll/hover/FloatingTab.java
@@ -20,6 +20,7 @@ import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.support.annotation.NonNull;
@@ -87,6 +88,14 @@ class FloatingTab extends FrameLayout {
         layoutParams.width = mTabSize;
         layoutParams.height = mTabSize;
         setLayoutParams(layoutParams);
+    }
+
+    @Override
+    protected void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        if (mDock != null) {
+            moveTo(mDock.position());
+        }
     }
 
     @Override


### PR DESCRIPTION
다행스럽게도 View 에서 Configuration Change 를 감지하는 메소드가 있었네요! @josh-yun 
https://developer.android.com/reference/android/view/View.html#onConfigurationChanged(android.content.res.Configuration)
HoverViewStateCollapsed 에서 구현된 View.OnLayoutChangeListener 는 Orientation Change 를 위한 것이니 이것으로 대체하고 제거했습니다