### PR TITLE
Hidden State으로 전환될 때 Animation 추가

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -101,6 +101,7 @@ public class HoverView extends RelativeLayout {
     boolean mIsTouchableInWindow;
     boolean mIsDebugMode = false;
     int mTabSize;
+    private PositionDock mPositionToHide;
     OnExitListener mOnExitListener;
     private final Set<OnStateChangeListener> mOnStateChangeListeners = new CopyOnWriteArraySet<>();
     private final Set<OnInteractionListener> mOnInteractionListeners = new CopyOnWriteArraySet<>();
@@ -243,6 +244,19 @@ public class HoverView extends RelativeLayout {
 
         mDragger.enableDebugMode(debugMode);
         mScreen.enableDrugMode(debugMode);
+    }
+
+    public void setPositionToHide(Point position) {
+        if (position == null) {
+            this.mPositionToHide = null;
+        } else {
+            this.mPositionToHide = new PositionDock(position);
+        }
+    }
+
+    @Nullable
+    public PositionDock getPositionToHide() {
+        return mPositionToHide;
     }
 
     void setState(@NonNull HoverViewState newState, Runnable onStateChanged) {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateHidden.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateHidden.java
@@ -50,7 +50,11 @@ class HoverViewStateHidden extends BaseHoverViewState {
                 new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        mHoverView.setVisibility(View.GONE);
+                        if (mHoverView != null) {
+                            mHoverView.setVisibility(View.GONE);
+                        } else {
+                            Log.e("Hidden", "HoverView is NULL!!!!!!!!");
+                        }
                     }
                 }, 50);
             }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateHidden.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateHidden.java
@@ -1,5 +1,7 @@
 package io.mattcarroll.hover;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.View;
@@ -8,17 +10,58 @@ class HoverViewStateHidden extends BaseHoverViewState {
 
     private static final String TAG = "HoverViewStateHidden";
 
+    private FloatingTab mSelectedTab;
+
     @Override
     public void takeControl(@NonNull final HoverView hoverView, final Runnable onStateChanged) {
         super.takeControl(hoverView, onStateChanged);
         Log.d(TAG, "Taking control.");
         mHoverView.makeUntouchableInWindow();
-        mHoverView.setVisibility(View.GONE);
+        mHoverView.clearFocus();
+
+        HoverMenu.Section mSelectedSection = mHoverView.mMenu.getSection(mHoverView.mSelectedSectionId);
+        if (mSelectedSection == null) {
+            mSelectedSection = mHoverView.mMenu.getSection(0);
+        }
+
+        mSelectedTab = mHoverView.mScreen.getChainedTab(mSelectedSection.getId());
+        if (mSelectedTab == null) {
+            mSelectedTab = mHoverView.mScreen.createChainedTab(mSelectedSection);
+        }
+
+        mSelectedTab.shrink();
+        mSelectedTab.setSelected(true);
+
+        final PositionDock positionToHide = mHoverView.getPositionToHide();
+        if (positionToHide == null) {
+            mHoverView.setVisibility(View.GONE);
+            onStateChanged.run();
+            return;
+        }
+
+        mSelectedTab.setDock(positionToHide);
+        mSelectedTab.dock(new Runnable() {
+            @Override
+            public void run() {
+                if (!hasControl() || !mHoverView.mIsAddedToWindow) {
+                    return;
+                }
+                onStateChanged.run();
+                new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        mHoverView.setVisibility(View.GONE);
+                    }
+                }, 50);
+            }
+        });
     }
 
     @Override
     public void giveUpControl(@NonNull HoverViewState nextState) {
         Log.d(TAG, "Giving up control.");
+        mSelectedTab.setSelected(false);
+        mSelectedTab.expand();
         mHoverView.setVisibility(View.VISIBLE);
         super.giveUpControl(nextState);
     }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateHidden.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateHidden.java
@@ -52,8 +52,6 @@ class HoverViewStateHidden extends BaseHoverViewState {
                     public void run() {
                         if (mHoverView != null) {
                             mHoverView.setVisibility(View.GONE);
-                        } else {
-                            Log.e("Hidden", "HoverView is NULL!!!!!!!!");
                         }
                     }
                 }, 50);


### PR DESCRIPTION
HiddenState로 state가 전환될 때, onStateChanged listener를 호출 한 후 바로 view의 visibility를 바꿀 경우 버튼이 깜빡거리는듯한 느낌을 주게됩니다. 그래서 handler를 사용해 약간의 딜레이를 넣었습니다.