### PR TITLE
[BZZRWRDD-322] Pop의 드래그가 시작되면 Preview가 닫히는 기능 구현

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -60,7 +60,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
                 if (mHoverView.shouldKeepVisible()) {
                     mHoverView.setAlpha(ALPHA_IDLE_VALUE);
                 } else {
-                    mHoverView.close();
+                    onClose(false);
                 }
             }
         }
@@ -201,12 +201,11 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mHoverView.notifyOnDragStart(this);
     }
 
-    protected void onDroppedByUser() {
+    private void onDroppedByUser() {
         mHoverView.mScreen.getExitView().setVisibility(GONE);
         boolean droppedOnExit = mHoverView.mScreen.getExitView().isInExitZone(mFloatingTab.getPosition());
         if (droppedOnExit) {
-            Log.d(TAG, "User dropped floating tab on exit.");
-            mHoverView.close();
+            onClose(true);
         } else {
             int tabSize = mHoverView.getResources().getDimensionPixelSize(R.dimen.hover_tab_size);
             Point screenSize = mHoverView.getScreenSize();
@@ -233,6 +232,15 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
 
             sendToDock();
         }
+    }
+
+    protected void onClose(final boolean userDropped) {
+        if (userDropped) {
+            Log.d(TAG, "User dropped floating tab on exit.");
+        } else {
+            Log.d(TAG, "Auto dropped.");
+        }
+        mHoverView.close();
     }
 
     private void onTap() {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -33,9 +33,9 @@ import static android.view.View.VISIBLE;
  * {@link HoverViewState} that operates the {@link HoverView} when it is collapsed. Collapsed means
  * that the only thing visible is the selected {@link FloatingTab}.  This tab docks itself against
  * the left or right sides of the screen.  The user can drag the tab around and drop it.
- *
+ * <p>
  * If the tab is tapped, the {@code HoverView} is transitioned to its expanded state.
- *
+ * <p>
  * If the tab is dropped on the exit region, the {@code HoverView} is transitioned to its closed state.
  */
 class HoverViewStateCollapsed extends BaseHoverViewState {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -195,7 +195,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         // No-op
     }
 
-    private void onPickedUpByUser() {
+    protected void onPickedUpByUser() {
         mHoverView.mScreen.getExitView().setVisibility(VISIBLE);
         restoreHoverViewAlphaValue();
         mHoverView.notifyOnDragStart(this);
@@ -277,7 +277,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
     }
 
-    private void onDocked() {
+    protected void onDocked() {
         Log.d(TAG, "Docked. Activating dragger.");
         if (!mHoverView.mIsAddedToWindow) {
             return;

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -201,7 +201,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mHoverView.notifyOnDragStart(this);
     }
 
-    private void onDroppedByUser() {
+    protected void onDroppedByUser() {
         mHoverView.mScreen.getExitView().setVisibility(GONE);
         boolean droppedOnExit = mHoverView.mScreen.getExitView().isInExitZone(mFloatingTab.getPosition());
         if (droppedOnExit) {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -31,6 +31,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
     private static final String TAG = "HoverViewStatePreviewed";
     private TabMessageView mMessageView;
+    private boolean mCollapseOnDocked = false;
 
     @Override
     public void takeControl(@NonNull HoverView hoverView, final Runnable onStateChanged) {
@@ -52,7 +53,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     public void giveUpControl(@NonNull final HoverViewState nextState) {
         Log.d(TAG, "Giving up control.");
-        if (nextState instanceof HoverViewStateCollapsed) {
+        if (nextState instanceof HoverViewStateCollapsed && !mCollapseOnDocked) {
             mMessageView.disappear(true);
         } else {
             mMessageView.disappear(false);
@@ -77,11 +78,27 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     }
 
     @Override
+    protected void onPickedUpByUser() {
+        mMessageView.disappear(true);
+        mCollapseOnDocked = true;
+        super.onPickedUpByUser();
+    }
+
+    @Override
     protected void activateDragger() {
         final ArrayList<View> list = new ArrayList<>();
         list.add(mFloatingTab);
         list.add(mMessageView);
         mHoverView.mDragger.activate(mDragListener, list);
+    }
+
+    @Override
+    protected void onDocked() {
+        super.onDocked();
+        if (mCollapseOnDocked) {
+            mHoverView.collapse();
+            mCollapseOnDocked = false;
+        }
     }
 
     @Override

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -89,9 +89,9 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     }
 
     @Override
-    protected void onDroppedByUser() {
+    protected void onClose(final boolean userDropped) {
+        super.onClose(userDropped);
         init();
-        super.onDroppedByUser();
     }
 
     @Override

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -33,6 +33,10 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     private TabMessageView mMessageView;
     private boolean mCollapseOnDocked = false;
 
+    HoverViewStatePreviewed() {
+        init();
+    }
+
     @Override
     public void takeControl(@NonNull HoverView hoverView, final Runnable onStateChanged) {
         super.takeControl(hoverView, null);
@@ -86,7 +90,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
     @Override
     protected void onDroppedByUser() {
-        mCollapseOnDocked = false;
+        init();
         super.onDroppedByUser();
     }
 
@@ -110,5 +114,9 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     public HoverViewStateType getStateType() {
         return HoverViewStateType.PREVIEWED;
+    }
+
+    private void init() {
+        mCollapseOnDocked = false;
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -32,7 +32,6 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     private static final String TAG = "HoverViewStatePreviewed";
     private TabMessageView mMessageView;
     private boolean mCollapseOnDocked = false;
-    private boolean mTurnOffNextCollapseAnimation = false;
 
     @Override
     public void takeControl(@NonNull HoverView hoverView, final Runnable onStateChanged) {
@@ -54,9 +53,9 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     public void giveUpControl(@NonNull final HoverViewState nextState) {
         Log.d(TAG, "Giving up control.");
-        if (nextState instanceof HoverViewStateCollapsed) {
-            mMessageView.disappear(!mTurnOffNextCollapseAnimation);
-            mTurnOffNextCollapseAnimation = false;
+        if (nextState instanceof HoverViewStateCollapsed
+                && mMessageView.getVisibility() == View.VISIBLE) {
+            mMessageView.disappear(true);
         } else {
             mMessageView.disappear(false);
         }
@@ -98,7 +97,6 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     protected void onDocked() {
         super.onDocked();
         if (mCollapseOnDocked) {
-            mTurnOffNextCollapseAnimation = true;
             mHoverView.collapse();
             mCollapseOnDocked = false;
         }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -85,6 +85,12 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     }
 
     @Override
+    protected void onDroppedByUser() {
+        mCollapseOnDocked = false;
+        super.onDroppedByUser();
+    }
+
+    @Override
     protected void activateDragger() {
         final ArrayList<View> list = new ArrayList<>();
         list.add(mFloatingTab);

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -53,8 +53,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     public void giveUpControl(@NonNull final HoverViewState nextState) {
         Log.d(TAG, "Giving up control.");
-        if (nextState instanceof HoverViewStateCollapsed
-                && mMessageView.getVisibility() == View.VISIBLE) {
+        if (nextState instanceof HoverViewStateCollapsed) {
             mMessageView.disappear(true);
         } else {
             mMessageView.disappear(false);

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -32,6 +32,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     private static final String TAG = "HoverViewStatePreviewed";
     private TabMessageView mMessageView;
     private boolean mCollapseOnDocked = false;
+    private boolean mTurnOffNextCollapseAnimation = false;
 
     @Override
     public void takeControl(@NonNull HoverView hoverView, final Runnable onStateChanged) {
@@ -53,8 +54,9 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     public void giveUpControl(@NonNull final HoverViewState nextState) {
         Log.d(TAG, "Giving up control.");
-        if (nextState instanceof HoverViewStateCollapsed && !mCollapseOnDocked) {
-            mMessageView.disappear(true);
+        if (nextState instanceof HoverViewStateCollapsed) {
+            mMessageView.disappear(!mTurnOffNextCollapseAnimation);
+            mTurnOffNextCollapseAnimation = false;
         } else {
             mMessageView.disappear(false);
         }
@@ -96,6 +98,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     protected void onDocked() {
         super.onDocked();
         if (mCollapseOnDocked) {
+            mTurnOffNextCollapseAnimation = true;
             mHoverView.collapse();
             mCollapseOnDocked = false;
         }

--- a/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
@@ -21,16 +21,27 @@ public class TabMessageView extends FrameLayout {
     private View mMessageView;
 
     private final FloatingTab.OnPositionChangeListener mOnTabPositionChangeListener = new FloatingTab.OnPositionChangeListener() {
+        private static final int DEFAULT_SIDE = SideDock.SidePosition.LEFT;
+
+        private Point mLastPosition;
+        private int mLastSide;
+
         @Override
         public void onPositionChange(@NonNull Point position) {
+            final Integer side = getSide();
+            if (side.equals(mLastSide) && position.equals(mLastPosition) || getWidth() == 0) {
+                return;
+            }
+            Log.d(TAG, mFloatingTab + " tab moved to " + position);
             final float tabSizeHalf = mFloatingTab.getTabSize() / 2f;
-            if (mSideDock != null && mSideDock.sidePosition().getSide() == SideDock.SidePosition.RIGHT) {
+            if (side == SideDock.SidePosition.RIGHT) {
                 setX(position.x - tabSizeHalf - getWidth());
-                setY(position.y - tabSizeHalf);
             } else {
                 setX(position.x + tabSizeHalf);
-                setY(position.y - tabSizeHalf);
             }
+            setY(position.y - tabSizeHalf);
+            mLastPosition = position;
+            mLastSide = side;
         }
 
         @Override
@@ -41,6 +52,13 @@ public class TabMessageView extends FrameLayout {
                     appear(sideDock, null);
                 }
             }
+        }
+
+        private int getSide() {
+            if (mSideDock != null) {
+                return mSideDock.sidePosition().getSide();
+            }
+            return DEFAULT_SIDE;
         }
     };
 

--- a/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
@@ -23,7 +23,6 @@ public class TabMessageView extends FrameLayout {
     private final FloatingTab.OnPositionChangeListener mOnTabPositionChangeListener = new FloatingTab.OnPositionChangeListener() {
         @Override
         public void onPositionChange(@NonNull Point position) {
-            Log.d(TAG, mFloatingTab + " tab moved to " + position);
             final float tabSizeHalf = mFloatingTab.getTabSize() / 2f;
             if (mSideDock != null && mSideDock.sidePosition().getSide() == SideDock.SidePosition.RIGHT) {
                 setX(position.x - tabSizeHalf - getWidth());

--- a/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
@@ -84,40 +84,42 @@ public class TabMessageView extends FrameLayout {
     public void appear(final SideDock dock, @Nullable final Runnable onAppeared) {
         mSideDock = dock;
         mFloatingTab.addOnPositionChangeListener(mOnTabPositionChangeListener);
-        final AnimationSet animation = new AnimationSet(true);
-        final AlphaAnimation alpha = new AlphaAnimation(0, 1);
-        final float fromXDelta = getResources().getDimensionPixelSize(R.dimen.hover_message_animate_translation_x)
-                * (dock.sidePosition().getSide() == SideDock.SidePosition.LEFT ? -1 : 1);
-        final float fromYDelta = getResources().getDimensionPixelSize(R.dimen.hover_message_animate_translation_y);
-        TranslateAnimation translate = new TranslateAnimation(fromXDelta, 0, fromYDelta, 0);
-        animation.setDuration(300);
-        animation.setInterpolator(new LinearOutSlowInInterpolator());
-        animation.addAnimation(alpha);
-        animation.addAnimation(translate);
-        animation.setAnimationListener(new Animation.AnimationListener() {
-            @Override
-            public void onAnimationStart(Animation animation) {
-            }
-
-            @Override
-            public void onAnimationEnd(Animation animation) {
-                if (onAppeared != null) {
-                    onAppeared.run();
+        if (getVisibility() != View.VISIBLE) {
+            final AnimationSet animation = new AnimationSet(true);
+            final AlphaAnimation alpha = new AlphaAnimation(0, 1);
+            final float fromXDelta = getResources().getDimensionPixelSize(R.dimen.hover_message_animate_translation_x)
+                    * (dock.sidePosition().getSide() == SideDock.SidePosition.LEFT ? -1 : 1);
+            final float fromYDelta = getResources().getDimensionPixelSize(R.dimen.hover_message_animate_translation_y);
+            TranslateAnimation translate = new TranslateAnimation(fromXDelta, 0, fromYDelta, 0);
+            animation.setDuration(300);
+            animation.setInterpolator(new LinearOutSlowInInterpolator());
+            animation.addAnimation(alpha);
+            animation.addAnimation(translate);
+            animation.setAnimationListener(new Animation.AnimationListener() {
+                @Override
+                public void onAnimationStart(Animation animation) {
                 }
-            }
 
-            @Override
-            public void onAnimationRepeat(Animation animation) {
-            }
-        });
-        startAnimation(animation);
-        setVisibility(VISIBLE);
+                @Override
+                public void onAnimationEnd(Animation animation) {
+                    if (onAppeared != null) {
+                        onAppeared.run();
+                    }
+                }
+
+                @Override
+                public void onAnimationRepeat(Animation animation) {
+                }
+            });
+            startAnimation(animation);
+            setVisibility(VISIBLE);
+        }
     }
 
     public void disappear(final boolean withAnimation) {
         mFloatingTab.removeOnPositionChangeListener(mOnTabPositionChangeListener);
         mSideDock = null;
-        if (withAnimation) {
+        if (withAnimation && getVisibility() == View.VISIBLE) {
             final AnimationSet animation = new AnimationSet(true);
             final AlphaAnimation alpha = new AlphaAnimation(1, 0);
             alpha.setDuration(300);


### PR DESCRIPTION
Preview 드래그 기능의 구현이 오래 걸릴 것 같으므로, 일단 현재 구현된 것들은 적용하고 가는 것이 좋을 것 같아 PR을 올립니다.

## 구현 사항
* Pop을 드래그하면 Preview가 사라지는 기능을 구현하였습니다.
* 위치 정보에 대해서 불필요하게 뜨는 로그를 제거하였습니다.

## 구현 상세
### Pop 드래그시 Preview 닫기
* HoverViewStatePreviewed.onPickedByUser()에서 messageView의 disappear를 애니메이션과 함께 실행하게 하고, mCollapseOnDocked를 true로 설정합니다.
* HoverViewStatePreviewed.onDocked()에서 mCollapseOnDocked가 true이면 collapse 상태로 변경합니다. 이 때, 애니메이션이 없도록 하기 위해서 mTurnOffNextCollapseAnimation를 true로 설정합니다.
* HoverViewStatePreviewed.onDroppedByUser()에서 변수들을 초기화합니다. 지금은 mCollapseOnDocked 필드 하나만 있습니다. Service는 HoverView를 매 번 새로 생성하지 않고, 한 번 생성한 후 재사용하기 때문에 Drop되는 시점에서 변수를 초기화 해주어야 합니다.
* TabMessageView의 appear()와 disappear()에서 애니메이션을 적용할 때, 현재 Visibility를 체크하여 애니메이션을 적용할지 여부를 결정합니다.

### 위치 정보 로그 제거
* (위치, 옆면)가 기존과 동일하고 getWidth()가 0이 아닌 경우에는 위치 정보에 대한 로그를 띄우지 않습니다. 기존에는 같은 위치 정보임에도 계속해서 여러개의 로그가 떠서 디버깅에 불편함이 있었습니다