### PR TITLE
[BZZRWRDD-322] Pop과 Preview의 터치/드래그 이벤트 등을 얻을 수 있도록 인터페이스 구현

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/BaseTouchController.java
+++ b/hover/src/main/java/io/mattcarroll/hover/BaseTouchController.java
@@ -61,11 +61,11 @@ public abstract class BaseTouchController {
         updateTouchControlViewAppearance();
     }
 
-    private TouchViewItem createTouchViewItem(final HoverFrameLayout originalView, final TouchListener listener, final String tag) {
+    private <T extends TouchListener<V>, V extends HoverFrameLayout> TouchViewItem createTouchViewItem(final V originalView, final T listener, final String tag) {
         return new TouchViewItem<>(originalView, createTouchViewFrom(originalView), listener, tag);
     }
 
-    protected TouchDetector createTouchDetector(final View originalView, final TouchListener touchListener) {
+    protected <T extends TouchListener<V>, V extends View> TouchDetector createTouchDetector(final V originalView, final T touchListener) {
         return new TouchDetector<>(originalView, touchListener);
     }
 
@@ -102,22 +102,22 @@ public abstract class BaseTouchController {
         return touchView;
     }
 
-    public interface TouchListener {
-        void onTap(View view);
+    public interface TouchListener <V extends View> {
+        void onTap(V view);
 
-        void onTouchDown(View view);
+        void onTouchDown(V view);
 
-        void onTouchUp(View view);
+        void onTouchUp(V view);
     }
 
-    protected class TouchDetector<T extends TouchListener> implements View.OnTouchListener {
+    protected class TouchDetector<T extends TouchListener<V>, V extends View> implements View.OnTouchListener {
 
         @NonNull
-        protected final View mOriginalView;
+        protected final V mOriginalView;
         @NonNull
         protected final T mEventListener;
 
-        TouchDetector(@NonNull final View originalView, @NonNull final T touchListener) {
+        TouchDetector(@NonNull final V originalView, @NonNull final T touchListener) {
             this.mOriginalView = originalView;
             this.mEventListener = touchListener;
         }
@@ -140,12 +140,12 @@ public abstract class BaseTouchController {
         }
     }
 
-    protected class TouchViewItem<T extends TouchListener> {
-        final HoverFrameLayout mOriginalView;
+    protected class TouchViewItem<V extends HoverFrameLayout, T extends TouchListener<V>> {
+        final V mOriginalView;
         final View mTouchView;
         final T mTouchListener;
 
-        TouchViewItem(final HoverFrameLayout originalView, final View touchView, final T touchListener, final String tag) {
+        TouchViewItem(final V originalView, final View touchView, final T touchListener, final String tag) {
             this.mOriginalView = originalView;
             this.mTouchView = touchView;
             this.mTouchListener = touchListener;

--- a/hover/src/main/java/io/mattcarroll/hover/BaseTouchController.java
+++ b/hover/src/main/java/io/mattcarroll/hover/BaseTouchController.java
@@ -3,6 +3,7 @@ package io.mattcarroll.hover;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
+import android.support.v4.util.Pair;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
@@ -14,34 +15,14 @@ import java.util.Map;
 public abstract class BaseTouchController {
     private static final String TAG = "BaseTouchController";
 
-    protected Map<String, View> mTouchViewMap = new HashMap<>();
-    protected TouchListener mTouchListener;
+    protected Map<String, TouchViewItem> mTouchViewMap = new HashMap<>();
     protected boolean mIsActivated;
     private boolean mIsDebugMode;
-    private List<View> mViewList;
-
-    private View.OnTouchListener mDragTouchListener = new View.OnTouchListener() {
-        @Override
-        public boolean onTouch(View view, MotionEvent motionEvent) {
-            switch (motionEvent.getAction()) {
-                case MotionEvent.ACTION_DOWN:
-                    Log.d(TAG, "ACTION_DOWN");
-                    mTouchListener.onPress();
-                    return true;
-                case MotionEvent.ACTION_UP:
-                    Log.d(TAG, "ACTION_UP");
-                    mTouchListener.onTap();
-                    return true;
-                default:
-                    return false;
-            }
-        }
-    };
 
     private final View.OnLayoutChangeListener mOnLayoutChangeListener = new View.OnLayoutChangeListener() {
         @Override
         public void onLayoutChange(View view, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-            moveTouchViewTo(mTouchViewMap.get(view.getTag()), new PointF(view.getX(), view.getY()));
+            moveTouchViewTo(mTouchViewMap.get(view.getTag()).mTouchView, new PointF(view.getX(), view.getY()));
         }
     };
 
@@ -51,25 +32,17 @@ public abstract class BaseTouchController {
 
     public abstract void moveTouchViewTo(@NonNull View touchView, @NonNull PointF position);
 
-    public void activate(@NonNull TouchListener touchListener, @NonNull List<View> viewList) {
+    public void activate(final List<Pair<? extends View, ? extends TouchListener>> viewList) {
         if (!mIsActivated) {
             Log.d(TAG, "Activating.");
             mIsActivated = true;
-            mTouchListener = touchListener;
-            mViewList = viewList;
-            mTouchViewMap.clear();
-            for (int i = 0; i < mViewList.size(); i++) {
-                View view = mViewList.get(i);
-                String tag = "view" + i;
-                view.setTag(tag);
-                Rect rect = new Rect();
-                view.getDrawingRect(rect);
-                View touchView = createTouchView(rect);
-                moveTouchViewTo(touchView, new PointF(view.getX(), view.getY()));
-                touchView.setOnTouchListener(mDragTouchListener);
-                touchView.setTag(tag);
-                mTouchViewMap.put(tag, touchView);
-                view.addOnLayoutChangeListener(mOnLayoutChangeListener);
+
+            clearTouchViewMap();
+            for (int i = 0; i < viewList.size(); i++) {
+                final Pair<? extends View, ? extends TouchListener> viewItem = viewList.get(i);
+                final String tag = "view" + i;
+                final TouchViewItem touchViewItem = createTouchViewItem(viewItem.first, viewItem.second, tag);
+                mTouchViewMap.put(tag, touchViewItem);
             }
             updateTouchControlViewAppearance();
         }
@@ -78,19 +51,8 @@ public abstract class BaseTouchController {
     public void deactivate() {
         if (mIsActivated) {
             Log.d(TAG, "Deactivating.");
-            for (View view : mViewList) {
-                view.setOnTouchListener(null);
-                view.removeOnLayoutChangeListener(mOnLayoutChangeListener);
-            }
-
-            for (View touchView : mTouchViewMap.values()) {
-                destroyTouchView(touchView);
-            }
-
+            clearTouchViewMap();
             mIsActivated = false;
-            mTouchViewMap.clear();
-            mViewList = null;
-            mTouchListener = null;
         }
     }
 
@@ -99,8 +61,34 @@ public abstract class BaseTouchController {
         updateTouchControlViewAppearance();
     }
 
+    private TouchViewItem createTouchViewItem(final View originalView, final TouchListener listener, final String tag) {
+        originalView.setTag(tag);
+
+        Rect rect = new Rect();
+        originalView.getDrawingRect(rect);
+        View touchView = createTouchView(rect);
+        moveTouchViewTo(touchView, new PointF(originalView.getX(), originalView.getY()));
+        touchView.setTag(tag);
+        final TouchViewItem touchViewItem = new TouchViewItem<>(originalView, touchView, listener);
+        setEventListener(touchViewItem);
+        originalView.addOnLayoutChangeListener(mOnLayoutChangeListener);
+        return touchViewItem;
+    }
+
+    protected void setEventListener(final TouchViewItem touchViewItem) {
+        touchViewItem.mTouchView.setOnTouchListener(new TouchDetector<>(touchViewItem.mOriginalView, touchViewItem.mTouchListener));
+    }
+
+    private void clearTouchViewMap() {
+        for (final TouchViewItem touchViewItem : mTouchViewMap.values()) {
+            touchViewItem.destroy();
+        }
+        mTouchViewMap.clear();
+    }
+
     private void updateTouchControlViewAppearance() {
-        for (View touchView : mTouchViewMap.values()) {
+        for (final TouchViewItem touchViewItemItem : mTouchViewMap.values()) {
+            final View touchView = touchViewItemItem.mTouchView;
             if (null != touchView) {
                 if (mIsDebugMode) {
                     touchView.setBackgroundColor(0x44FF0000);
@@ -112,8 +100,53 @@ public abstract class BaseTouchController {
     }
 
     public interface TouchListener {
-        void onPress();
+        void onPress(View view);
 
-        void onTap();
+        void onTap(View view);
+    }
+
+    protected class TouchDetector<T extends TouchListener> implements View.OnTouchListener {
+
+        protected final View mOriginalView;
+        protected final T mEventListener;
+
+        TouchDetector(final View originalView, final T touchListener) {
+            this.mOriginalView = originalView;
+            this.mEventListener = touchListener;
+        }
+
+        @Override
+        public boolean onTouch(View view, MotionEvent motionEvent) {
+            switch (motionEvent.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    Log.d(TAG, "ACTION_DOWN");
+                    mEventListener.onPress(mOriginalView);
+                    return true;
+                case MotionEvent.ACTION_UP:
+                    Log.d(TAG, "ACTION_UP");
+                    mEventListener.onTap(mOriginalView);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    protected class TouchViewItem<T extends TouchListener> {
+        final View mOriginalView;
+        final View mTouchView;
+        final T mTouchListener;
+
+        TouchViewItem(final View originalView, final View touchView, final T touchListener) {
+            this.mOriginalView = originalView;
+            this.mTouchView = touchView;
+            this.mTouchListener = touchListener;
+        }
+
+        void destroy() {
+            mOriginalView.setOnTouchListener(null);
+            mOriginalView.removeOnLayoutChangeListener(mOnLayoutChangeListener);
+            destroyTouchView(mTouchView);
+        }
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/BaseTouchController.java
+++ b/hover/src/main/java/io/mattcarroll/hover/BaseTouchController.java
@@ -103,17 +103,21 @@ public abstract class BaseTouchController {
     }
 
     public interface TouchListener {
-        void onPress(View view);
-
         void onTap(View view);
+
+        void onTouchDown(View view);
+
+        void onTouchUp(View view);
     }
 
     protected class TouchDetector<T extends TouchListener> implements View.OnTouchListener {
 
+        @NonNull
         protected final View mOriginalView;
+        @NonNull
         protected final T mEventListener;
 
-        TouchDetector(final View originalView, final T touchListener) {
+        TouchDetector(@NonNull final View originalView, @NonNull final T touchListener) {
             this.mOriginalView = originalView;
             this.mEventListener = touchListener;
         }
@@ -123,10 +127,11 @@ public abstract class BaseTouchController {
             switch (motionEvent.getAction()) {
                 case MotionEvent.ACTION_DOWN:
                     Log.d(TAG, "ACTION_DOWN");
-                    mEventListener.onPress(mOriginalView);
+                    mEventListener.onTouchDown(mOriginalView);
                     return true;
                 case MotionEvent.ACTION_UP:
                     Log.d(TAG, "ACTION_UP");
+                    mEventListener.onTouchUp(mOriginalView);
                     mEventListener.onTap(mOriginalView);
                     return true;
                 default:

--- a/hover/src/main/java/io/mattcarroll/hover/ContentDisplay.java
+++ b/hover/src/main/java/io/mattcarroll/hover/ContentDisplay.java
@@ -62,7 +62,8 @@ class ContentDisplay extends RelativeLayout {
 
     private final FloatingTab.OnPositionChangeListener mOnTabPositionChangeListener = new FloatingTab.OnPositionChangeListener() {
         @Override
-        public void onPositionChange(@NonNull Point position) {
+        public void onPositionChange(@NonNull View view) {
+            final Point position = new Point((int) view.getX() + (view.getWidth() / 2), (int) view.getY() + (view.getHeight() / 2));
             Log.d(TAG, mSelectedTab + " tab moved to " + position);
             updateTabSelectorPosition();
 
@@ -70,11 +71,6 @@ class ContentDisplay extends RelativeLayout {
 
             // We have received an affirmative position for the selected tab. Show tab selector.
             mTabSelectorView.setVisibility(VISIBLE);
-        }
-
-        @Override
-        public void onDockChange(@NonNull Dock dock) {
-            // No-op.
         }
     };
 

--- a/hover/src/main/java/io/mattcarroll/hover/Dragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Dragger.java
@@ -39,8 +39,12 @@ public abstract class Dragger extends BaseTouchController {
     public abstract Point getContainerSize();
 
     @Override
-    protected void setEventListener(final TouchViewItem touchViewItem) {
-        touchViewItem.mTouchView.setOnTouchListener(new DragDetector(touchViewItem.mOriginalView, (DragListener) touchViewItem.mTouchListener));
+    protected TouchDetector createTouchDetector(final View originalView, TouchListener touchListener) {
+        if (touchListener instanceof DragListener) {
+            return new DragDetector(originalView, (DragListener) touchListener);
+        } else {
+            return super.createTouchDetector(originalView, touchListener);
+        }
     }
 
     private boolean isTouchWithinSlopOfOriginalTouch(float dx, float dy) {

--- a/hover/src/main/java/io/mattcarroll/hover/Dragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Dragger.java
@@ -95,6 +95,13 @@ public abstract class Dragger extends BaseTouchController {
          * @param y    y-coordiante of the user's release (in the parent View's coordinate space)
          */
         void onReleasedAt(V view, float x, float y);
+
+        /**
+         * The drag is cancelled (ex: due to screen off).
+         *
+         * @param view the view that is being dragged
+         */
+        void onDragCancel(V view);
     }
 
     private class DragDetector<T extends DragListener<V>, V extends View> extends TouchDetector<T, V> {
@@ -152,7 +159,15 @@ public abstract class Dragger extends BaseTouchController {
                     } else {
                         Log.d(TAG, "Reporting as a drag release at: " + mCurrentViewPosition);
                         mEventListener.onReleasedAt(mOriginalView, mCurrentViewPosition.x, mCurrentViewPosition.y);
+                        mIsDragging = false;
                     }
+                    return true;
+                case MotionEvent.ACTION_CANCEL:
+                    Log.d(TAG, "ACTION_CANCEL");
+                    if (mIsDragging) {
+                        mEventListener.onDragCancel(mOriginalView);
+                    }
+                    mIsDragging = false;
                     return true;
                 default:
                     return false;

--- a/hover/src/main/java/io/mattcarroll/hover/Dragger.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Dragger.java
@@ -125,14 +125,9 @@ public abstract class Dragger extends BaseTouchController {
                     mOriginalViewPosition = convertCornerToCenter(view, getTouchViewPosition(view));
                     mCurrentViewPosition = new PointF(mOriginalViewPosition.x, mOriginalViewPosition.y);
                     mOriginalTouchPosition.set(motionEvent.getRawX(), motionEvent.getRawY());
-                    if (mEventListener != null) {
-                        mEventListener.onPress(mOriginalView);
-                    }
+                    mEventListener.onTouchDown(view);
                     return true;
                 case MotionEvent.ACTION_MOVE:
-                    if (mEventListener == null) {
-                        return false;
-                    }
                     Log.d(TAG, "ACTION_MOVE. motionX: " + motionEvent.getRawX() + ", motionY: " + motionEvent.getRawY());
                     float dragDeltaX = motionEvent.getRawX() - mOriginalTouchPosition.x;
                     float dragDeltaY = motionEvent.getRawY() - mOriginalTouchPosition.y;
@@ -150,12 +145,11 @@ public abstract class Dragger extends BaseTouchController {
                     return true;
                 case MotionEvent.ACTION_UP:
                     Log.d(TAG, "ACTION_UP");
+                    mEventListener.onTouchUp(view);
                     if (!mIsDragging) {
                         Log.d(TAG, "Reporting as a tap.");
-                        if (mEventListener != null) {
-                            mEventListener.onTap(mOriginalView);
-                        }
-                    } else if (mEventListener != null) {
+                        mEventListener.onTap(mOriginalView);
+                    } else {
                         Log.d(TAG, "Reporting as a drag release at: " + mCurrentViewPosition);
                         mEventListener.onReleasedAt(mOriginalView, mCurrentViewPosition.x, mCurrentViewPosition.y);
                     }

--- a/hover/src/main/java/io/mattcarroll/hover/FloatingTab.java
+++ b/hover/src/main/java/io/mattcarroll/hover/FloatingTab.java
@@ -94,7 +94,7 @@ class FloatingTab extends FrameLayout {
     protected void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         if (mDock != null) {
-            moveTo(mDock.position());
+            moveCenterTo(mDock.position());
         }
     }
 
@@ -287,11 +287,11 @@ class FloatingTab extends FrameLayout {
     }
 
     public void dockImmediately() {
-        moveTo(mDock.position());
+        moveCenterTo(mDock.position());
     }
 
-    public void moveTo(@NonNull Point floatPosition) {
-        Point cornerPosition = convertCenterToCorner(floatPosition);
+    public void moveCenterTo(@NonNull Point centerPosition) {
+        Point cornerPosition = convertCenterToCorner(centerPosition);
         setX(cornerPosition.x);
         setY(cornerPosition.y);
         notifyListenersOfPositionChange();

--- a/hover/src/main/java/io/mattcarroll/hover/HoverFrameLayout.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverFrameLayout.java
@@ -1,0 +1,72 @@
+package io.mattcarroll.hover;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+class HoverFrameLayout extends FrameLayout {
+
+    protected final Set<OnPositionChangeListener> mOnPositionChangeListeners = new CopyOnWriteArraySet<>();
+    private final OnLayoutChangeListener mOnLayoutChangeListener = new OnLayoutChangeListener() {
+        @Override
+        public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+            notifyListenersOfPositionChange(v);
+        }
+    };
+
+    public HoverFrameLayout(@NonNull Context context) {
+        super(context);
+    }
+
+    public HoverFrameLayout(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public HoverFrameLayout(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public HoverFrameLayout(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public void addOnPositionChangeListener(@Nullable OnPositionChangeListener listener) {
+        mOnPositionChangeListeners.add(listener);
+    }
+
+    public void removeOnPositionChangeListener(@NonNull OnPositionChangeListener listener) {
+        mOnPositionChangeListeners.remove(listener);
+    }
+
+    protected void notifyListenersOfPositionChange(final View view) {
+        for (OnPositionChangeListener listener : mOnPositionChangeListeners) {
+            listener.onPositionChange(view);
+        }
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        addOnLayoutChangeListener(mOnLayoutChangeListener);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        removeOnLayoutChangeListener(mOnLayoutChangeListener);
+    }
+
+    interface OnPositionChangeListener {
+        void onPositionChange(@NonNull View view);
+    }
+}
+

--- a/hover/src/main/java/io/mattcarroll/hover/HoverMenu.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverMenu.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 /**
  * A {@code HoverMenu} models the structure of a menu that appears within a {@link HoverView}.
- *
+ * <p>
  * A {@code HoverMenu} includes an ordered list of {@link Section}s.  Each {@code Section} has a tab
  * {@code View} that represents the section, and the {@link Content} of the given section.
  */
@@ -34,8 +34,13 @@ public abstract class HoverMenu {
 
     private static final String TAG = "HoverMenu";
 
+    public enum HoverMenuState {
+        IDLE, REMOVE_PREVIEW
+    }
+
     private List<Section> mSections = new ArrayList<>();
     private ListUpdateCallback mListUpdateCallback;
+    private HoverMenuState mState = HoverMenuState.IDLE;
 
     public abstract String getId();
 
@@ -59,6 +64,8 @@ public abstract class HoverMenu {
     @NonNull
     public abstract List<Section> getSections();
 
+    protected abstract void onHoverMenuStateChanged(HoverMenuState state);
+
     void setUpdatedCallback(@Nullable ListUpdateCallback listUpdatedCallback) {
         mListUpdateCallback = listUpdatedCallback;
     }
@@ -74,6 +81,14 @@ public abstract class HoverMenu {
             // expect many Sections.
             DiffUtil.DiffResult result = DiffUtil.calculateDiff(diffCallback, true);
             result.dispatchUpdatesTo(mListUpdateCallback);
+        }
+    }
+
+    public void setState(final HoverMenuState newState) {
+        final boolean changed = this.mState != newState;
+        this.mState = newState;
+        if (changed) {
+            onHoverMenuStateChanged(this.mState);
         }
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverMenu.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverMenu.java
@@ -34,13 +34,8 @@ public abstract class HoverMenu {
 
     private static final String TAG = "HoverMenu";
 
-    public enum HoverMenuState {
-        IDLE, REMOVE_PREVIEW
-    }
-
     private List<Section> mSections = new ArrayList<>();
     private ListUpdateCallback mListUpdateCallback;
-    private HoverMenuState mState = HoverMenuState.IDLE;
 
     public abstract String getId();
 
@@ -64,8 +59,6 @@ public abstract class HoverMenu {
     @NonNull
     public abstract List<Section> getSections();
 
-    protected abstract void onHoverMenuStateChanged(HoverMenuState state);
-
     void setUpdatedCallback(@Nullable ListUpdateCallback listUpdatedCallback) {
         mListUpdateCallback = listUpdatedCallback;
     }
@@ -81,14 +74,6 @@ public abstract class HoverMenu {
             // expect many Sections.
             DiffUtil.DiffResult result = DiffUtil.calculateDiff(diffCallback, true);
             result.dispatchUpdatesTo(mListUpdateCallback);
-        }
-    }
-
-    public void setState(final HoverMenuState newState) {
-        final boolean changed = this.mState != newState;
-        this.mState = newState;
-        if (changed) {
-            onHoverMenuStateChanged(this.mState);
         }
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -408,15 +408,15 @@ public class HoverView extends RelativeLayout {
         }
     }
 
-    void notifyMessageViewOnTouchDown() {
+    void notifyMessageViewOnTouchDown(final TabMessageView tabMessageView) {
         for (final OnTabMessageViewInteractionListener listener : mOnTabMessageViewInteractionListeners) {
-            listener.onTouchDown();
+            listener.onTouchDown(tabMessageView);
         }
     }
 
-    void notifyMessageViewOnTouchUp() {
+    void notifyMessageViewOnTouchUp(final TabMessageView tabMessageView) {
         for (final OnTabMessageViewInteractionListener listener : mOnTabMessageViewInteractionListeners) {
-            listener.onTouchUp();
+            listener.onTouchUp(tabMessageView);
         }
     }
 
@@ -676,8 +676,8 @@ public class HoverView extends RelativeLayout {
     }
 
     public interface OnTabMessageViewInteractionListener {
-        void onTouchDown();
+        void onTouchDown(TabMessageView tabMessageView);
 
-        void onTouchUp();
+        void onTouchUp(TabMessageView tabMessageView);
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -105,7 +105,6 @@ public class HoverView extends RelativeLayout {
     OnExitListener mOnExitListener;
     private final Set<OnStateChangeListener> mOnStateChangeListeners = new CopyOnWriteArraySet<>();
     private final Set<OnFloatingTabInteractionListener> mOnFloatingTabInteractionListeners = new CopyOnWriteArraySet<>();
-    private final Set<OnTabMessageViewInteractionListener> mOnTabMessageViewInteractionListeners = new CopyOnWriteArraySet<>();
     private boolean mKeepVisible;
 
     // Public for use with XML inflation. Clients should use static methods for construction.
@@ -275,6 +274,10 @@ public class HoverView extends RelativeLayout {
         return mState;
     }
 
+    public void setMessageViewDragListener(@Nullable final Dragger.DragListener<TabMessageView> messageViewDragListener) {
+        ((HoverViewStatePreviewed) mPreviewed).setMessageViewDragListener(messageViewDragListener);
+    }
+
     private void onBackPressed() {
         mState.onBackPressed();
     }
@@ -381,15 +384,6 @@ public class HoverView extends RelativeLayout {
         mOnFloatingTabInteractionListeners.remove(onFloatingTabInteractionListener);
     }
 
-    public void addOnTabMessageViewInteractionListener(@NonNull OnTabMessageViewInteractionListener onTabMessageViewInteractionListener) {
-        mOnTabMessageViewInteractionListeners.add(onTabMessageViewInteractionListener);
-    }
-
-    public void removeOnTabMessageViewInteractionListener(@NonNull OnTabMessageViewInteractionListener onTabMessageViewInteractionListener) {
-        mOnTabMessageViewInteractionListeners.remove(onTabMessageViewInteractionListener);
-    }
-
-
     void notifyOnTap(HoverViewState state) {
         for (OnFloatingTabInteractionListener onFloatingTabInteractionListener : mOnFloatingTabInteractionListeners) {
             onFloatingTabInteractionListener.onTap(state.getStateType());
@@ -405,18 +399,6 @@ public class HoverView extends RelativeLayout {
     void notifyOnDocked(HoverViewState state) {
         for (OnFloatingTabInteractionListener onFloatingTabInteractionListener : mOnFloatingTabInteractionListeners) {
             onFloatingTabInteractionListener.onDocked(state.getStateType());
-        }
-    }
-
-    void notifyMessageViewOnTouchDown(final TabMessageView tabMessageView) {
-        for (final OnTabMessageViewInteractionListener listener : mOnTabMessageViewInteractionListeners) {
-            listener.onTouchDown(tabMessageView);
-        }
-    }
-
-    void notifyMessageViewOnTouchUp(final TabMessageView tabMessageView) {
-        for (final OnTabMessageViewInteractionListener listener : mOnTabMessageViewInteractionListeners) {
-            listener.onTouchUp(tabMessageView);
         }
     }
 
@@ -675,9 +657,4 @@ public class HoverView extends RelativeLayout {
         void onDocked(HoverViewStateType stateType);
     }
 
-    public interface OnTabMessageViewInteractionListener {
-        void onTouchDown(TabMessageView tabMessageView);
-
-        void onTouchUp(TabMessageView tabMessageView);
-    }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -274,7 +274,7 @@ public class HoverView extends RelativeLayout {
         return mState;
     }
 
-    public void setMessageViewDragListener(@Nullable final Dragger.DragListener<TabMessageView> messageViewDragListener) {
+    public void setTabMessageViewInteractionListener(@Nullable final OnTabMessageViewInteractionListener messageViewDragListener) {
         ((HoverViewStatePreviewed) mPreviewed).setMessageViewDragListener(messageViewDragListener);
     }
 
@@ -665,4 +665,6 @@ public class HoverView extends RelativeLayout {
         void onDocked(HoverViewStateType stateType);
     }
 
+    public abstract static class OnTabMessageViewInteractionListener implements Dragger.DragListener<TabMessageView> {
+    }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -104,7 +104,8 @@ public class HoverView extends RelativeLayout {
     private PositionDock mPositionToHide;
     OnExitListener mOnExitListener;
     private final Set<OnStateChangeListener> mOnStateChangeListeners = new CopyOnWriteArraySet<>();
-    private final Set<OnInteractionListener> mOnInteractionListeners = new CopyOnWriteArraySet<>();
+    private final Set<OnFloatingTabInteractionListener> mOnFloatingTabInteractionListeners = new CopyOnWriteArraySet<>();
+    private final Set<OnTabMessageViewInteractionListener> mOnTabMessageViewInteractionListeners = new CopyOnWriteArraySet<>();
     private boolean mKeepVisible;
 
     // Public for use with XML inflation. Clients should use static methods for construction.
@@ -372,29 +373,50 @@ public class HoverView extends RelativeLayout {
         mOnStateChangeListeners.remove(onStateChangeListener);
     }
 
-    public void addOnInteractionListener(@NonNull OnInteractionListener onInteractionListener) {
-        mOnInteractionListeners.add(onInteractionListener);
+    public void addOnFloatingTabInteractionListener(@NonNull OnFloatingTabInteractionListener onFloatingTabInteractionListener) {
+        mOnFloatingTabInteractionListeners.add(onFloatingTabInteractionListener);
     }
 
-    public void removeOnInteractionListener(@NonNull OnInteractionListener onInteractionListener) {
-        mOnInteractionListeners.remove(onInteractionListener);
+    public void removeOnFloatingTabInteractionListener(@NonNull OnFloatingTabInteractionListener onFloatingTabInteractionListener) {
+        mOnFloatingTabInteractionListeners.remove(onFloatingTabInteractionListener);
     }
+
+    public void addOnTabMessageViewInteractionListener(@NonNull OnTabMessageViewInteractionListener onTabMessageViewInteractionListener) {
+        mOnTabMessageViewInteractionListeners.add(onTabMessageViewInteractionListener);
+    }
+
+    public void removeOnTabMessageViewInteractionListener(@NonNull OnTabMessageViewInteractionListener onTabMessageViewInteractionListener) {
+        mOnTabMessageViewInteractionListeners.remove(onTabMessageViewInteractionListener);
+    }
+
 
     void notifyOnTap(HoverViewState state) {
-        for (OnInteractionListener onInteractionListener : mOnInteractionListeners) {
-            onInteractionListener.onTap(state.getStateType());
+        for (OnFloatingTabInteractionListener onFloatingTabInteractionListener : mOnFloatingTabInteractionListeners) {
+            onFloatingTabInteractionListener.onTap(state.getStateType());
         }
     }
 
     void notifyOnDragStart(HoverViewState state) {
-        for (OnInteractionListener onInteractionListener : mOnInteractionListeners) {
-            onInteractionListener.onDragStart(state.getStateType());
+        for (OnFloatingTabInteractionListener onFloatingTabInteractionListener : mOnFloatingTabInteractionListeners) {
+            onFloatingTabInteractionListener.onDragStart(state.getStateType());
         }
     }
 
     void notifyOnDocked(HoverViewState state) {
-        for (OnInteractionListener onInteractionListener : mOnInteractionListeners) {
-            onInteractionListener.onDocked(state.getStateType());
+        for (OnFloatingTabInteractionListener onFloatingTabInteractionListener : mOnFloatingTabInteractionListeners) {
+            onFloatingTabInteractionListener.onDocked(state.getStateType());
+        }
+    }
+
+    void notifyMessageViewOnTouchDown() {
+        for (final OnTabMessageViewInteractionListener listener : mOnTabMessageViewInteractionListeners) {
+            listener.onTouchDown();
+        }
+    }
+
+    void notifyMessageViewOnTouchUp() {
+        for (final OnTabMessageViewInteractionListener listener : mOnTabMessageViewInteractionListeners) {
+            listener.onTouchUp();
         }
     }
 
@@ -645,11 +667,17 @@ public class HoverView extends RelativeLayout {
         }
     }
 
-    public interface OnInteractionListener {
+    public interface OnFloatingTabInteractionListener {
         void onTap(HoverViewStateType stateType);
 
         void onDragStart(HoverViewStateType stateType);
 
         void onDocked(HoverViewStateType stateType);
+    }
+
+    public interface OnTabMessageViewInteractionListener {
+        void onTouchDown();
+
+        void onTouchUp();
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -431,6 +431,14 @@ public class HoverView extends RelativeLayout {
         }
     }
 
+    @Nullable
+    public TabMessageView getTabMessageView() {
+        if (mScreen == null) {
+            return null;
+        }
+        return mScreen.getTabMessageView(mSelectedSectionId);
+    }
+
     void makeTouchableInWindow() {
         mIsTouchableInWindow = true;
         if (mIsAddedToWindow) {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -290,6 +290,10 @@ public class HoverView extends RelativeLayout {
         if (null == mSelectedSectionId || null == mMenu.getSection(mSelectedSectionId)) {
             mSelectedSectionId = mMenu.getSection(0).getId();
         }
+        final FloatingTab selectedTab = mScreen.getChainedTab(mSelectedSectionId);
+        if (selectedTab != null) {
+            selectedTab.setTabView(mMenu.getSection(mSelectedSectionId).getTabView());
+        }
         mState.setMenu(menu);
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -272,7 +272,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
                 mHoverView.getScreenSize(),
                 mFloatingTab.getTabSize()
         );
-        mFloatingTab.moveTo(dockPosition);
+        mFloatingTab.moveCenterTo(dockPosition);
     }
 
     private void initDockPosition() {
@@ -307,7 +307,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     }
 
     void moveFloatingTabTo(View floatingTab, @NonNull Point position) {
-        mFloatingTab.moveTo(position);
+        mFloatingTab.moveCenterTo(position);
     }
 
     protected void activateDragger() {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -358,6 +358,11 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
 
         @Override
+        public void onDragCancel(FloatingTab floatingTab) {
+            mOwner.onDroppedByUser();
+        }
+
+        @Override
         public void onTap(FloatingTab floatingTab) {
             mOwner.onTap();
         }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -311,7 +311,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     }
 
     protected void activateDragger() {
-        ArrayList<Pair<? extends View, ? extends BaseTouchController.TouchListener>> list = new ArrayList<>();
+        ArrayList<Pair<? extends HoverFrameLayout, ? extends BaseTouchController.TouchListener>> list = new ArrayList<>();
         list.add(new Pair<>(mFloatingTab, mFloatingTabDragListener));
         mHoverView.mDragger.activate(list);
     }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -369,12 +369,16 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
 
         @Override
-        public void onPress(View floatingTab) {
+        public void onTap(View floatingTab) {
+            mOwner.onTap();
         }
 
         @Override
-        public void onTap(View floatingTab) {
-            mOwner.onTap();
+        public void onTouchDown(View floatingTab) {
+        }
+
+        @Override
+        public void onTouchUp(View floatingTab) {
         }
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -48,7 +48,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     private static final float ALPHA_IDLE_VALUE = 0.4f;
 
     protected FloatingTab mFloatingTab;
-    protected final Dragger.DragListener mFloatingTabDragListener = new FloatingTabDragListener(this);
+    protected final FloatingTabDragListener mFloatingTabDragListener = new FloatingTabDragListener(this);
     protected HoverMenu.Section mSelectedSection;
     private int mSelectedSectionIndex = -1;
     private boolean mIsCollapsed = false;
@@ -123,7 +123,6 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
 
         scheduleHoverViewAlphaChange();
-        setHoverMenuMode(HoverMenu.HoverMenuState.IDLE);
     }
 
     @Override
@@ -330,22 +329,12 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mHoverView.setAlpha(1f);
     }
 
-    protected void setHoverMenuMode(final HoverMenu.HoverMenuState state) {
-        if (mHoverView == null) {
-            return;
-        }
-        if (mHoverView.mMenu == null) {
-            return;
-        }
-        mHoverView.mMenu.setState(state);
-    }
-
     @Override
     public HoverViewStateType getStateType() {
         return HoverViewStateType.COLLAPSED;
     }
 
-    protected static final class FloatingTabDragListener implements Dragger.DragListener {
+    protected static final class FloatingTabDragListener implements Dragger.DragListener<FloatingTab> {
 
         private final HoverViewStateCollapsed mOwner;
 
@@ -354,31 +343,31 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
 
         @Override
-        public void onDragStart(View floatingTab, float x, float y) {
+        public void onDragStart(FloatingTab floatingTab, float x, float y) {
             mOwner.onPickedUpByUser();
         }
 
         @Override
-        public void onDragTo(View floatingTab, float x, float y) {
+        public void onDragTo(FloatingTab floatingTab, float x, float y) {
             mOwner.moveFloatingTabTo(floatingTab, new Point((int) x, (int) y));
         }
 
         @Override
-        public void onReleasedAt(View floatingTab, float x, float y) {
+        public void onReleasedAt(FloatingTab floatingTab, float x, float y) {
             mOwner.onDroppedByUser();
         }
 
         @Override
-        public void onTap(View floatingTab) {
+        public void onTap(FloatingTab floatingTab) {
             mOwner.onTap();
         }
 
         @Override
-        public void onTouchDown(View floatingTab) {
+        public void onTouchDown(FloatingTab floatingTab) {
         }
 
         @Override
-        public void onTouchUp(View floatingTab) {
+        public void onTouchUp(FloatingTab floatingTab) {
         }
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -19,6 +19,7 @@ import android.graphics.Point;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.util.Pair;
 import android.support.v7.util.ListUpdateCallback;
 import android.util.Log;
 import android.view.View;
@@ -47,7 +48,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     private static final float ALPHA_IDLE_VALUE = 0.4f;
 
     protected FloatingTab mFloatingTab;
-    protected final Dragger.DragListener mDragListener = new FloatingTabDragListener(this);
+    protected final Dragger.DragListener mFloatingTabDragListener = new FloatingTabDragListener(this);
     protected HoverMenu.Section mSelectedSection;
     private int mSelectedSectionIndex = -1;
     private boolean mIsCollapsed = false;
@@ -68,8 +69,8 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     private Runnable mOnStateChanged;
 
     @Override
-    public void takeControl(@NonNull HoverView hoverView, final Runnable onStateChanged) {
-        super.takeControl(hoverView, onStateChanged);
+    public void takeControl(@NonNull HoverView floatingTab, final Runnable onStateChanged) {
+        super.takeControl(floatingTab, onStateChanged);
         Log.d(TAG, "Taking control.");
         mOnStateChanged = onStateChanged;
         mHoverView.makeUntouchableInWindow();
@@ -243,7 +244,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mHoverView.close();
     }
 
-    private void onTap() {
+    protected void onTap() {
         Log.d(TAG, "Floating tab was tapped.");
         if (mHoverView != null) {
             mHoverView.notifyOnTap(this);
@@ -305,14 +306,14 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         mHoverView.notifyOnDocked(this);
     }
 
-    protected void moveTabTo(View touchView, @NonNull Point position) {
+    void moveFloatingTabTo(View floatingTab, @NonNull Point position) {
         mFloatingTab.moveTo(position);
     }
 
     protected void activateDragger() {
-        ArrayList<View> list = new ArrayList<>();
-        list.add(mFloatingTab);
-        mHoverView.mDragger.activate(mDragListener, list);
+        ArrayList<Pair<? extends View, ? extends BaseTouchController.TouchListener>> list = new ArrayList<>();
+        list.add(new Pair<>(mFloatingTab, mFloatingTabDragListener));
+        mHoverView.mDragger.activate(list);
     }
 
     protected void deactivateDragger() {
@@ -342,26 +343,26 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
 
         @Override
-        public void onDragStart(View touchView, float x, float y) {
+        public void onDragStart(View floatingTab, float x, float y) {
             mOwner.onPickedUpByUser();
         }
 
         @Override
-        public void onDragTo(View touchView, float x, float y) {
-            mOwner.moveTabTo(touchView, new Point((int) x, (int) y));
+        public void onDragTo(View floatingTab, float x, float y) {
+            mOwner.moveFloatingTabTo(floatingTab, new Point((int) x, (int) y));
         }
 
         @Override
-        public void onReleasedAt(View touchView, float x, float y) {
+        public void onReleasedAt(View floatingTab, float x, float y) {
             mOwner.onDroppedByUser();
         }
 
         @Override
-        public void onPress() {
+        public void onPress(View floatingTab) {
         }
 
         @Override
-        public void onTap() {
+        public void onTap(View floatingTab) {
             mOwner.onTap();
         }
     }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -123,6 +123,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
         }
 
         scheduleHoverViewAlphaChange();
+        setHoverMenuMode(HoverMenu.HoverMenuState.IDLE);
     }
 
     @Override
@@ -327,6 +328,16 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     protected void restoreHoverViewAlphaValue() {
         mHandler.removeCallbacks(mAlphaChanger);
         mHoverView.setAlpha(1f);
+    }
+
+    protected void setHoverMenuMode(final HoverMenu.HoverMenuState state) {
+        if (mHoverView == null) {
+            return;
+        }
+        if (mHoverView.mMenu == null) {
+            return;
+        }
+        mHoverView.mMenu.setState(state);
     }
 
     @Override

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -52,6 +52,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
                     return;
                 }
                 onStateChanged.run();
+                activateDragger();
             }
         });
     }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -120,11 +120,12 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
         @Override
         public void onDragStart(View messageView, float x, float y) {
-            mOriginalX = messageView.getX() + messageView.getWidth() / 2;
-            mOriginalY = messageView.getY() + messageView.getHeight() / 2;
             if (messageView instanceof TabMessageView) {
+                mOriginalX = messageView.getX() + messageView.getWidth() / 2;
+                mOriginalY = messageView.getY() + messageView.getHeight() / 2;
                 ((TabMessageView) messageView).moveCenterTo(new Point((int) x, (int) mOriginalY));
                 updateAlpha(messageView, x);
+                mOwner.setHoverMenuMode(HoverMenu.HoverMenuState.REMOVE_PREVIEW);
             }
         }
 
@@ -142,6 +143,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
                 ((TabMessageView) messageView).moveCenterTo(new Point((int) mOriginalX, (int) mOriginalY));
                 updateAlpha(messageView, mOriginalX);
             }
+            mOwner.setHoverMenuMode(HoverMenu.HoverMenuState.IDLE);
             init();
         }
 

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -117,18 +117,18 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
         mHoverView.collapse();
     }
 
-    private void notifyTabMessageViewOnTouchDown() {
+    private void notifyTabMessageViewOnTouchDown(final TabMessageView tabMessageView) {
         if (mHoverView == null) {
             return;
         }
-        mHoverView.notifyMessageViewOnTouchDown();
+        mHoverView.notifyMessageViewOnTouchDown(tabMessageView);
     }
 
-    private void notifyTabMessageViewOnTouchUp() {
+    private void notifyTabMessageViewOnTouchUp(final TabMessageView tabMessageView) {
         if (mHoverView == null) {
             return;
         }
-        mHoverView.notifyMessageViewOnTouchUp();
+        mHoverView.notifyMessageViewOnTouchUp(tabMessageView);
     }
 
     protected static final class MessageViewDragListener implements Dragger.DragListener {
@@ -185,12 +185,16 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
         @Override
         public void onTouchDown(View messageView) {
-            mOwner.notifyTabMessageViewOnTouchDown();
+            if (messageView instanceof TabMessageView) {
+                mOwner.notifyTabMessageViewOnTouchDown((TabMessageView) messageView);
+            }
         }
 
         @Override
         public void onTouchUp(View messageView) {
-            mOwner.notifyTabMessageViewOnTouchUp();
+            if (messageView instanceof TabMessageView) {
+                mOwner.notifyTabMessageViewOnTouchUp((TabMessageView) messageView);
+            }
         }
 
         private void init() {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -124,6 +124,13 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
             }
             mCustomMessageViewDragListener.onReleasedAt(view, x, y);
         }
+        @Override
+        public void onDragCancel(TabMessageView view) {
+            if (mCustomMessageViewDragListener == null) {
+                return;
+            }
+            mCustomMessageViewDragListener.onDragCancel(view);
+        }
 
         @Override
         public void onTap(TabMessageView view) {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -108,6 +108,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
     protected static final class MessageViewDragListener implements Dragger.DragListener {
 
+        private static final float ALPHA_THRESHOLD = 400;
         private final HoverViewStateCollapsed mOwner;
         private float mOriginalX;
         private float mOriginalY;
@@ -123,6 +124,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
             mOriginalY = messageView.getY() + messageView.getHeight() / 2;
             if (messageView instanceof TabMessageView) {
                 ((TabMessageView) messageView).moveCenterTo(new Point((int) x, (int) mOriginalY));
+                updateAlpha(messageView, x);
             }
         }
 
@@ -130,6 +132,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
         public void onDragTo(View messageView, float x, float y) {
             if (messageView instanceof TabMessageView) {
                 ((TabMessageView) messageView).moveCenterTo(new Point((int) x, (int) mOriginalY));
+                updateAlpha(messageView, x);
             }
         }
 
@@ -137,6 +140,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
         public void onReleasedAt(View messageView, float x, float y) {
             if (messageView instanceof TabMessageView) {
                 ((TabMessageView) messageView).moveCenterTo(new Point((int) mOriginalX, (int) mOriginalY));
+                updateAlpha(messageView, mOriginalX);
             }
             init();
         }
@@ -153,6 +157,10 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
         private void init() {
             mOriginalX = 0;
             mOriginalY = 0;
+        }
+
+        private void updateAlpha(final View view, final float current) {
+            view.setAlpha(1 - Math.max(0, Math.min(1, (Math.abs(current - mOriginalX) / ALPHA_THRESHOLD))));
         }
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -117,15 +117,29 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
         mHoverView.collapse();
     }
 
+    private void notifyTabMessageViewOnTouchDown() {
+        if (mHoverView == null) {
+            return;
+        }
+        mHoverView.notifyMessageViewOnTouchDown();
+    }
+
+    private void notifyTabMessageViewOnTouchUp() {
+        if (mHoverView == null) {
+            return;
+        }
+        mHoverView.notifyMessageViewOnTouchUp();
+    }
+
     protected static final class MessageViewDragListener implements Dragger.DragListener {
 
         private static final float ALPHA_THRESHOLD = 400;
         private static final float COLLAPSE_THRESHOLD = 300;
-        private final HoverViewStateCollapsed mOwner;
+        private final HoverViewStatePreviewed mOwner;
         private float mOriginalX;
         private float mOriginalY;
 
-        protected MessageViewDragListener(@NonNull HoverViewStateCollapsed owner) {
+        protected MessageViewDragListener(@NonNull HoverViewStatePreviewed owner) {
             mOwner = owner;
             init();
         }
@@ -157,9 +171,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
                 updateAlpha(messageView, mOriginalX);
                 if (Math.abs(x - mOriginalX) > COLLAPSE_THRESHOLD) {
                     updateAlpha(messageView, mOriginalX);
-                    if (mOwner instanceof HoverViewStatePreviewed) {
-                        ((HoverViewStatePreviewed) mOwner).hidePreview(getAlpha(x));
-                    }
+                    mOwner.hidePreview(getAlpha(x));
                 }
             }
             mOwner.setHoverMenuMode(HoverMenu.HoverMenuState.IDLE);
@@ -167,12 +179,18 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
         }
 
         @Override
-        public void onPress(View messageView) {
+        public void onTap(View messageView) {
+            mOwner.onTap();
         }
 
         @Override
-        public void onTap(View messageView) {
-            mOwner.onTap();
+        public void onTouchDown(View messageView) {
+            mOwner.notifyTabMessageViewOnTouchDown();
+        }
+
+        @Override
+        public void onTouchUp(View messageView) {
+            mOwner.notifyTabMessageViewOnTouchUp();
         }
 
         private void init() {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -32,11 +32,9 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     private TabMessageView mMessageView;
     private Dragger.DragListener<TabMessageView> mDefaultMessageViewDragListener;
     private Dragger.DragListener<TabMessageView> mCustomMessageViewDragListener;
-    private boolean mCollapseOnDocked = false;
 
     HoverViewStatePreviewed() {
         mDefaultMessageViewDragListener = new DefaultMessageViewDragListener();
-        init();
     }
 
     @Override
@@ -70,15 +68,12 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
     @Override
     protected void onPickedUpByUser() {
-        mMessageView.disappear(true);
-        mCollapseOnDocked = true;
         super.onPickedUpByUser();
     }
 
     @Override
     protected void onClose(final boolean userDropped) {
         super.onClose(userDropped);
-        init();
     }
 
     @Override
@@ -92,10 +87,6 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     @Override
     protected void onDocked() {
         super.onDocked();
-        if (mCollapseOnDocked) {
-            mHoverView.collapse();
-            mCollapseOnDocked = false;
-        }
     }
 
     @Override
@@ -105,10 +96,6 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
     public void setMessageViewDragListener(final Dragger.DragListener<TabMessageView> messageViewDragListener) {
         this.mCustomMessageViewDragListener = messageViewDragListener;
-    }
-
-    private void init() {
-        mCollapseOnDocked = false;
     }
 
     private class DefaultMessageViewDragListener implements Dragger.DragListener<TabMessageView> {

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStatePreviewed.java
@@ -82,7 +82,7 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
 
     @Override
     protected void activateDragger() {
-        ArrayList<Pair<? extends View, ? extends BaseTouchController.TouchListener>> list = new ArrayList<>();
+        ArrayList<Pair<? extends HoverFrameLayout, ? extends BaseTouchController.TouchListener>> list = new ArrayList<>();
         list.add(new Pair<>(mFloatingTab, mFloatingTabDragListener));
         list.add(new Pair<>(mMessageView, mMessageViewDragListener));
         mHoverView.mDragger.activate(list);
@@ -109,24 +109,36 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
     protected static final class MessageViewDragListener implements Dragger.DragListener {
 
         private final HoverViewStateCollapsed mOwner;
+        private float mOriginalX;
+        private float mOriginalY;
 
         protected MessageViewDragListener(@NonNull HoverViewStateCollapsed owner) {
             mOwner = owner;
+            init();
         }
 
         @Override
         public void onDragStart(View messageView, float x, float y) {
+            mOriginalX = messageView.getX() + messageView.getWidth() / 2;
+            mOriginalY = messageView.getY() + messageView.getHeight() / 2;
+            if (messageView instanceof TabMessageView) {
+                ((TabMessageView) messageView).moveCenterTo(new Point((int) x, (int) mOriginalY));
+            }
         }
 
         @Override
         public void onDragTo(View messageView, float x, float y) {
             if (messageView instanceof TabMessageView) {
-                ((TabMessageView) messageView).moveTo(new Point((int) x, (int) y));
+                ((TabMessageView) messageView).moveCenterTo(new Point((int) x, (int) mOriginalY));
             }
         }
 
         @Override
         public void onReleasedAt(View messageView, float x, float y) {
+            if (messageView instanceof TabMessageView) {
+                ((TabMessageView) messageView).moveCenterTo(new Point((int) mOriginalX, (int) mOriginalY));
+            }
+            init();
         }
 
         @Override
@@ -136,6 +148,11 @@ class HoverViewStatePreviewed extends HoverViewStateCollapsed {
         @Override
         public void onTap(View messageView) {
             mOwner.onTap();
+        }
+
+        private void init() {
+            mOriginalX = 0;
+            mOriginalY = 0;
         }
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/Screen.java
+++ b/hover/src/main/java/io/mattcarroll/hover/Screen.java
@@ -95,10 +95,10 @@ class Screen {
             FloatingTab chainedTab = new FloatingTab(mContainer.getContext(), tabId);
             chainedTab.setTabView(tabView);
             chainedTab.enableDebugMode(mIsDebugMode);
-            mContainer.addView(chainedTab);
             mTabs.put(tabId, chainedTab);
             final TabMessageView messageView = new TabMessageView(tabView.getContext(), chainedTab);
             mContainer.addView(messageView);
+            mContainer.addView(chainedTab);
             mTabMessageViews.put(tabId, messageView);
             return chainedTab;
         }

--- a/hover/src/main/java/io/mattcarroll/hover/TabChain.java
+++ b/hover/src/main/java/io/mattcarroll/hover/TabChain.java
@@ -21,9 +21,6 @@ import android.support.annotation.Nullable;
 import android.util.Log;
 import android.view.View;
 
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
 /**
  * Connects one {@link FloatingTab}s position to that of another {@link FloatingTab}. The space
  * between the tabs can be configured at construction time.
@@ -36,11 +33,10 @@ class TabChain {
     private final int mTabSpacingInPx;
     private Point mLockedPosition;
     private FloatingTab mPredecessorTab;
-    private final Set<FloatingTab.OnPositionChangeListener> mOnPositionChangeListeners = new CopyOnWriteArraySet<FloatingTab.OnPositionChangeListener>();
 
-    private final FloatingTab.OnPositionChangeListener mOnPredecessorPositionChange = new FloatingTab.OnPositionChangeListener() {
+    private final FloatingTab.OnFloatingTabChangeListener mOnPredecessorPositionChange = new FloatingTab.OnFloatingTabChangeListener() {
         @Override
-        public void onPositionChange(@NonNull Point position) {
+        public void onPositionChange(@NonNull View view) {
             // No-op. We only care when our predecessor's dock changes.
         }
 

--- a/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
@@ -128,4 +128,9 @@ public class TabMessageView extends FrameLayout {
         }
         setVisibility(GONE);
     }
+
+    public void moveTo(@NonNull Point newPosition) {
+        setX(newPosition.x);
+        setY(newPosition.y);
+    }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
@@ -120,11 +120,14 @@ public class TabMessageView extends HoverFrameLayout {
     }
 
     public void disappear(final boolean withAnimation) {
+        disappear(withAnimation, 1);
+    }
+    public void disappear(final boolean withAnimation, float startAlpha) {
         mFloatingTab.removeOnPositionChangeListener(mOnFloatingTabChangeListener);
         mSideDock = null;
         if (withAnimation && getVisibility() == View.VISIBLE) {
             final AnimationSet animation = new AnimationSet(true);
-            final AlphaAnimation alpha = new AlphaAnimation(1, 0);
+            final AlphaAnimation alpha = new AlphaAnimation(startAlpha, 0);
             alpha.setDuration(300);
             animation.addAnimation(alpha);
             startAnimation(animation);

--- a/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
@@ -67,10 +67,13 @@ public class TabMessageView extends HoverFrameLayout {
 
     public TabMessageView(@NonNull Context context, @NonNull FloatingTab floatingTab) {
         super(context);
-        setClipToPadding(false);
-        setClipChildren(false);
         mFloatingTab = floatingTab;
         setVisibility(GONE);
+
+        // To prevent child's shadow clipping
+        setClipToPadding(false);
+        setClipChildren(false);
+        setPadding(10, 20, 10, 20);
     }
 
     public void setMessageView(@Nullable View view) {
@@ -122,6 +125,7 @@ public class TabMessageView extends HoverFrameLayout {
     public void disappear(final boolean withAnimation) {
         disappear(withAnimation, 1);
     }
+
     public void disappear(final boolean withAnimation, float startAlpha) {
         mFloatingTab.removeOnPositionChangeListener(mOnFloatingTabChangeListener);
         mSideDock = null;


### PR DESCRIPTION
변경 사항이 많아서 한 번 코드 리뷰를 하고 가는 것이 좋을 것 같습니다.
HS QA버전 나가고 나면 머지하면 어떨까 싶습니다.

## 구현된 기능
Preview를 옆으로 드래그해서 없앨 수 있습니다.

## 변경 내역
* Pop과 Preview의 드래그 이벤트를 서로 다른 것으로 구분하여 동작합니다.
    * 이를 위해서 `Dragger.mDragTouchListener`와 `BaseTouchController.mDragTouchListener`를 각각 `TouchDetector`, `DragDetector` 클래스로 만들고 View에 따라서 적절하게 생성하는 것으로 변경하였습니다.
    * Pop의 드래그 이벤트는 `HoverViewStateCollapsed.FloatingTabDragListener`에서 구현하고 있습니다.
    * Preview의 드래그 이벤트는 `HoverViewStatePreviewed.DefaultMessageViewDragListener`에서 구현하고 있습니다.
* 터치 영역의 위치 조정을 onLayoutChangeListener에서 하던 것을 커스텀 콜백인 onPositionChangeListener에서 하도록 변경하였습니다. 이는 setX(), setY()등의 애니메이션을 사용하는 경우 onLayoutChangeListener()가 불리지 않기 때문입니다.
* Menu가 업데이트되면 TabView를 업데이트하도록 하였습니다. 기존 구현에서는 Pop이 보이는 상태에서 다시 SHOW_POP 버튼을 누른 경우, 화면에는 이전에 생성된 FAB가 보이지만 코드로 접근하는 FAB 객체는 새로 생성된 객체인 문제가 있었습니다.
* Preview가 보이고 나서 약 1초 정도 터치가 안되는 문제가 있어서, fadeIn 애니메이션이 끝나면 바로 터치 영역을 활성화하게 하였습니다.
* Jetty의 요청에 따라 Preview가 Pop보다 아래에 위치하게 하였습니다.
