### PR TITLE
낮은 버전의 안드로이드에서 alpha값이 적용되지 않는 버그 수정

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -58,7 +58,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
             final HoverViewState state = mHoverView.getState();
             if (!(state instanceof HoverViewStatePreviewed) && state instanceof HoverViewStateCollapsed) {
                 if (mHoverView.shouldKeepVisible()) {
-                    mHoverView.setAlpha(ALPHA_IDLE_VALUE);
+                    mFloatingTab.setAlpha(ALPHA_IDLE_VALUE);
                 } else {
                     onClose(false);
                 }


### PR DESCRIPTION
낮은 버전의 안드로이드(21 이전)에서 ViewGroup에 setAlpha를 할 때 적용이 안되는 이슈가 있어서 floatingTabView의 Alpha 값을 변경하도록 코드를 수정했습니다.