### PR TITLE
Data Tracking에 필요한 인터페이스 구현

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/HoverView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverView.java
@@ -26,6 +26,7 @@ import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.WindowManager;
 import android.widget.RelativeLayout;
@@ -105,7 +106,7 @@ public class HoverView extends RelativeLayout {
     OnExitListener mOnExitListener;
     private final Set<OnStateChangeListener> mOnStateChangeListeners = new CopyOnWriteArraySet<>();
     private final Set<OnFloatingTabInteractionListener> mOnFloatingTabInteractionListeners = new CopyOnWriteArraySet<>();
-    private boolean mKeepVisible;
+    private HoverViewIdleAction mIdleAction;
 
     // Public for use with XML inflation. Clients should use static methods for construction.
     public HoverView(@NonNull Context context, @Nullable AttributeSet attrs) {
@@ -356,12 +357,12 @@ public class HoverView extends RelativeLayout {
         });
     }
 
-    public void setKeepVisible(boolean keepVisible) {
-        this.mKeepVisible = keepVisible;
+    public void setIdleAction(HoverViewIdleAction idleAction) {
+        this.mIdleAction = idleAction;
     }
 
-    public boolean shouldKeepVisible() {
-        return mKeepVisible;
+    public HoverViewIdleAction getIdleAction() {
+        return mIdleAction;
     }
 
     public void setOnExitListener(@Nullable OnExitListener listener) {
@@ -666,5 +667,11 @@ public class HoverView extends RelativeLayout {
     }
 
     public abstract static class OnTabMessageViewInteractionListener implements Dragger.DragListener<TabMessageView> {
+    }
+
+    public interface HoverViewIdleAction {
+        void changeState(View iconView);
+
+        void restoreState(View iconView);
     }
 }

--- a/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/TabMessageView.java
@@ -87,6 +87,11 @@ public class TabMessageView extends HoverFrameLayout {
         }
     }
 
+    @Nullable
+    public View getMessageView() {
+        return mMessageView;
+    }
+
     public void appear(final SideDock dock, @Nullable final Runnable onAppeared) {
         mSideDock = dock;
         mFloatingTab.addOnPositionChangeListener(mOnFloatingTabChangeListener);


### PR DESCRIPTION
Pop 관련 data를 hover library에서 보내는 것은 아닌 것 같아 인터페이스를 추가하였습니다.
- TabMessageView가 가지고있는 messageView를 가져올 수 있게 바꾸어 현재 보여지고있는 view가 ad인지 content인지 구분 할 수 있게 되었습니다.
- Pop의 idle모드를 boolean 값으로 visibility만 바꿀 수 있는 상태였는데요. 이 부분을 View의 상태를 직접 변경할 수 있도록 인터페이스를 만들어 외부에서 동작을 정의할 수 있도록 변경하였습니다.