### PR TITLE
OnExitListener가 의미대로 동작하지 않는 문제 수정

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateClosed.java
@@ -43,9 +43,6 @@ class HoverViewStateClosed extends BaseHoverViewState {
                         return;
                     }
                     mHoverView.mScreen.destroyChainedTab(selectedTab);
-                    if (null != mHoverView.mOnExitListener) {
-                        mHoverView.mOnExitListener.onExit();
-                    }
                     onStateChanged.run();
                 }
             });

--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -225,6 +225,9 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     protected void onClose(final boolean userDropped) {
         if (userDropped) {
             Log.d(TAG, "User dropped floating tab on exit.");
+            if (null != mHoverView.mOnExitListener) {
+                mHoverView.mOnExitListener.onExit();
+            }
         } else {
             Log.d(TAG, "Auto dropped.");
         }


### PR DESCRIPTION
OnExitListener가 close state으로 변경되면 무조건 불리고 있습니다.
유저가 강제로 끌 경우에만 호출이 되도록 변경을 하였습니다.

close state으로 가는 경우는 stateChangedListener의  onClosed()를 통해 할 수 있습니다.