### PR TITLE
Hover crash fix

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
+++ b/hover/src/main/java/io/mattcarroll/hover/HoverViewStateCollapsed.java
@@ -184,12 +184,20 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     }
 
     protected void onPickedUpByUser() {
+        if (!hasControl()) {
+            return;
+        }
+
         mHoverView.mScreen.getExitView().setVisibility(VISIBLE);
         restoreHoverViewIdleAction();
         mHoverView.notifyOnDragStart(this);
     }
 
     private void onDroppedByUser() {
+        if (!hasControl()) {
+            return;
+        }
+
         mHoverView.mScreen.getExitView().setVisibility(GONE);
         boolean droppedOnExit = mHoverView.mScreen.getExitView().isInExitZone(mFloatingTab.getPosition());
         if (droppedOnExit) {
@@ -223,6 +231,10 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
     }
 
     protected void onClose(final boolean userDropped) {
+        if (!hasControl()) {
+            return;
+        }
+
         if (userDropped) {
             Log.d(TAG, "User dropped floating tab on exit.");
             if (null != mHoverView.mOnExitListener) {
@@ -278,7 +290,7 @@ class HoverViewStateCollapsed extends BaseHoverViewState {
 
     protected void onDocked() {
         Log.d(TAG, "Docked. Activating dragger.");
-        if (!mHoverView.mIsAddedToWindow) {
+        if (!hasControl() || !mHoverView.mIsAddedToWindow) {
             return;
         }
         activateDragger();


### PR DESCRIPTION
다음과 같은 상황에서 crash가 발생하는 이슈를 수정하였습니다.

- 시간이 지나서 Pop이 자동으로 close state로 전환이 되기 직전에 터치를 시작 할 경우, long press 이벤트가 HoverView가 사라지고나서 불리게되어 NPE가 발생
    - Touch/Drag 이벤트가 불릴때 현재 state의 hasControl 여부를 확인하여 동작을 수행하도록 변경

- 사용자가 overlay permission을 revoke 할 경우, window에 view를 add하거나 layout을 업데이트하면 Exception이 발생
    - addView -> WindowManager.BadTokenException permission denied 발생
    - updateLayout -> IllegalArgumentException -> View가 window에 붙어있지 않아 업데이트 불가 에러