### PR TITLE
[CD-403] Remove hover android:allowBackup="false"

### DIFF
--- a/hover/src/main/AndroidManifest.xml
+++ b/hover/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
-    <application android:allowBackup="false">
+    <application>
 
     </application>
 


### PR DESCRIPTION
@techjin hover의 `<application android:allowBackup="false"> `때문에 제거하는 작업을했는데 이전 커밋에서 androidx 작업된것은 1.6.9 버전대에 문제 없을까요?